### PR TITLE
Use r10k and create symlinks

### DIFF
--- a/examples/allinone/10_setup_master.sh
+++ b/examples/allinone/10_setup_master.sh
@@ -1,15 +1,12 @@
 #!/bin/bash
 # Set up the Puppet Master
 
+r10k -v info puppetfile install
 vagrant ssh puppet -c "sudo service iptables stop; \
 sudo rpm -i http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm; \
 sudo yum install -y puppet-server; \
-sudo yum install -y git; \
 sudo rmdir /etc/puppet/modules || sudo unlink /etc/puppet/modules; \
 sudo ln -s /vagrant/modules /etc/puppet/modules; \
 sudo ln -s /vagrant/site.pp /etc/puppet/manifests/site.pp; \
-sudo gem install librarian-puppet --no-ri --no-rdoc; \
-cd /vagrant; \
-sudo librarian-puppet install --verbose --path /vagrant/modules; \
 sudo service puppetmaster start;\
 sudo puppet agent -t;"

--- a/examples/allinone/Puppetfile
+++ b/examples/allinone/Puppetfile
@@ -1,9 +1,1 @@
-forge "http://forge.puppetlabs.com"
-
-mod "puppetlabs/puppetdb"
-mod "puppetlabs/ntp"
-mod "puppetlabs/openstack"
-mod "puppetlabs/mysql", "0.6.1"
-mod "puppetlabs/mongodb"
-
-# vim:ft=ruby
+../../Puppetfile

--- a/examples/vagrant/10_setup_master.sh
+++ b/examples/vagrant/10_setup_master.sh
@@ -1,16 +1,13 @@
 #!/bin/bash
 # Set up the Puppet Master
 
+r10k -v info puppetfile install
 vagrant ssh puppet -c "sudo service iptables stop; \
 sudo rpm -i http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm; \
 sudo yum install -y puppet-server; \
-sudo yum install -y git; \
 sudo rmdir /etc/puppet/modules; \
 sudo ln -s /vagrant/modules /etc/puppet/modules; \
 sudo ln -s /vagrant/site.pp /etc/puppet/manifests/site.pp; \
-sudo gem install librarian-puppet --no-ri --no-rdoc; \
-cd /vagrant; \
-sudo librarian-puppet install --verbose --path /vagrant/modules; \
 sudo service puppetmaster start;\
 sudo puppet agent -t; \
 sudo puppet apply --modulepath /etc/puppet/modules -e \"class { '::puppetdb': listen_address => '0.0.0.0', ssl_listen_address => '0.0.0.0' } class { 'puppetdb::master::config': puppetdb_server => 'puppet'}\""

--- a/examples/vagrant/Puppetfile
+++ b/examples/vagrant/Puppetfile
@@ -1,9 +1,1 @@
-forge "http://forge.puppetlabs.com"
-
-mod "puppetlabs/puppetdb"
-mod "puppetlabs/ntp"
-mod "puppetlabs/openstack"
-mod "puppetlabs/mysql", "0.6.1"
-mod "puppetlabs/mongodb"
-
-# vim:ft=ruby
+../../Puppetfile


### PR DESCRIPTION
librarian-puppet is sloooooooow at trying to resolve dependencies.

This requires r10k to be installed (gems or whatever) on the host os.

This works with the review_checkout.py tool.
