### PR TITLE
Fix #53 iscsi_ip_address set to data_network ip_address

### DIFF
--- a/manifests/profile/cinder/volume.pp
+++ b/manifests/profile/cinder/volume.pp
@@ -1,11 +1,13 @@
 # The profile to install the volume service
 class havana::profile::cinder::volume {
+  $management_network = hiera('havana::network::management')
+  $management_address = ip_for_network($management_network)
 
   havana::resources::firewall { 'ISCSI API': port => '3260', }
 
   include ::havana::common::cinder
 
-  class { '::cinder::setup_test_volume': 
+  class { '::cinder::setup_test_volume':
     volume_name => 'cinder-volumes',
     size        => hiera('havana::cinder::volume_size')
   } ->
@@ -16,7 +18,7 @@ class havana::profile::cinder::volume {
   }
 
   class { '::cinder::volume::iscsi':
-    iscsi_ip_address  => hiera('havana::storage::address::management'),
+    iscsi_ip_address  => $management_address,
     volume_group      => 'cinder-volumes',
   }
 }


### PR DESCRIPTION
iscsi_ip_address is set to the data ip address of the host that profile::cinder::volume is been set.
