### PR TITLE
Update tempest stuff for multi-node

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -125,5 +125,5 @@ mod "postgresql",
 
 mod "puppetdb",
   :git => "git://github.com/puppetlabs/puppetlabs-puppetdb",
-  :ref => "1.5.x"
+  :ref => "3.0.1"
 

--- a/examples/common.yaml
+++ b/examples/common.yaml
@@ -42,6 +42,8 @@ havana::keystone::admin_password: 'fyby-tet'
 havana::tenants:
     "test":
         description: "Test tenant"
+    "test2":
+        description: "Test tenant"
 
 havana::users:
     "test":
@@ -49,6 +51,16 @@ havana::users:
         tenant: "test"
         email: "test@example.com"
         admin: true
+    "demo":
+        password: "abc123"
+        tenant: "test"
+        email: "demo@example.com"
+        admin: false
+    "demo2":
+        password: "abc123"
+        tenant: "test2"
+        email: "demo@example.com"
+        admin: false
 
 ######## Glance
 
@@ -87,6 +99,24 @@ havana::heat::encryption_key: 'heatsecretkey'
 ######## Horizon
 
 havana::horizon::secret_key: 'whu-ghuk'
+
+######## Tempest
+
+havana::tempest::configure_images    : true
+havana::tempest::image_name          : 'cirros'
+havana::tempest::image_name_alt      : 'cirros'
+havana::tempest::username            : 'demo'
+havana::tempest::username_alt        : 'demo2'
+havana::tempest::username_admin      : 'test'
+havana::tempest::configure_network   : true
+havana::tempest::public_network_name : 'public'
+havana::tempest::cinder_available    : true
+havana::tempest::glance_available    : true
+havana::tempest::horizon_available   : true
+havana::tempest::nova_available      : true
+havana::tempest::neutron_available   : true
+havana::tempest::heat_available      : false
+havana::tempest::swift_available     : false
 
 ######## Log levels
 havana::verbose: 'True'

--- a/examples/vagrant/10_setup_master.sh
+++ b/examples/vagrant/10_setup_master.sh
@@ -5,7 +5,7 @@ r10k -v info puppetfile install
 vagrant ssh puppet -c "sudo service iptables stop; \
 sudo rpm -i http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm; \
 sudo yum install -y puppet-server; \
-sudo rmdir /etc/puppet/modules; \
+sudo rmdir /etc/puppet/modules || sudo unlink /etc/puppet/modules; \
 sudo ln -s /vagrant/modules /etc/puppet/modules; \
 sudo ln -s /vagrant/site.pp /etc/puppet/manifests/site.pp; \
 sudo service puppetmaster start;\

--- a/examples/vagrant/41_run_tempest.sh
+++ b/examples/vagrant/41_run_tempest.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Run tempest
+vagrant ssh control -c "sudo /var/lib/tempest/run_tests.sh"

--- a/manifests/profile/tempest.pp
+++ b/manifests/profile/tempest.pp
@@ -32,6 +32,6 @@ class havana::profile::tempest {
     alt_username          => $alt_user,
     alt_password          => $users[$alt_user]['password'],
     alt_tenant_name       => $users[$alt_user]['tenant'],
-    require               => Neutron_network[$public_network_name],
+    #require              => Neutron_network[$public_network_name],
   }
 }

--- a/manifests/role/controller.pp
+++ b/manifests/role/controller.pp
@@ -14,5 +14,5 @@ class havana::role::controller inherits ::havana::role {
   class { '::havana::profile::heat::api': } ->
   class { '::havana::profile::horizon': }
   class { '::havana::profile::auth_file': }
-  class { '::havana::profile::tempest': }
+  #class { '::havana::profile::tempest': }
 }

--- a/manifests/role/storage.pp
+++ b/manifests/role/storage.pp
@@ -2,4 +2,6 @@ class havana::role::storage inherits ::havana::role {
   class { '::havana::profile::firewall': }
   class { '::havana::profile::glance::api': }
   class { '::havana::profile::cinder::volume': }
+
+  class { '::havana::setup::cirros': }
 }


### PR DESCRIPTION
The puppetdb module needs a 3.x version to work.

One issue is that the tempest_glance_id_setter resource uses the
glance_image resource type, which expects an /etc/glance/glance.conf
file to exist. Since this doesn't exist on the controller, it doesn't
work yet.

Another issue is that the public_network_id needs to be added to the
tempest.conf, but can't until the public network exists. So it has to be
run again after the network node is configured.

This at least gets the code into the tree.
