### PR TITLE
Updated Tempest testing framework for smoketests

### DIFF
--- a/examples/allinone/11_setup_havana.sh
+++ b/examples/allinone/11_setup_havana.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Mount the Havana module on the Puppet Master
-vagrant ssh puppet -c "sudo ln -s /havana /etc/puppet/modules; \
-sudo ln -s /havana/examples/hiera.yaml /etc/puppet/hiera.yaml; \
+# Mount the OpenStack module on the Puppet Master
+vagrant ssh puppet -c "sudo ln -s /openstack /etc/puppet/modules; \
+sudo ln -s /openstack/examples/hiera.yaml /etc/puppet/hiera.yaml; \
 sudo mkdir -p /etc/puppet/hieradata; \
-sudo ln -s /havana/examples/allinone.yaml /etc/puppet/hieradata/common.yaml; \
+sudo ln -s /openstack/examples/allinone.yaml /etc/puppet/hieradata/common.yaml; \
 sudo service puppetmaster restart;"

--- a/examples/allinone/35_run_tempest.sh
+++ b/examples/allinone/35_run_tempest.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Run tempest
-vagrant ssh allinone -c "sudo /var/lib/tempest/run_tests.sh"
+vagrant ssh allinone -c "sudo /var/lib/tempest/run_tests.sh -s"

--- a/examples/allinone/Vagrantfile
+++ b/examples/allinone/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     puppet.vm.hostname = "puppet"
 
-    puppet.vm.synced_folder "../../", "/havana"
+    puppet.vm.synced_folder "../../", "/openstack"
 
     puppet.vm.provider "vmware_fusion" do |v|
         v.vmx["memsize"] =  "1024"
@@ -35,7 +35,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     allinone.vm.hostname = "allinone"
 
-    allinone.vm.synced_folder "../../", "/havana"
+    allinone.vm.synced_folder "../../", "/openstack"
 
     allinone.vm.provider "vmware_fusion" do |v|
         v.vmx["memsize"] =  "6144"

--- a/examples/vagrant/41_run_tempest.sh
+++ b/examples/vagrant/41_run_tempest.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Run tempest
-vagrant ssh control -c "sudo /var/lib/tempest/run_tests.sh"
+vagrant ssh control -c "sudo /var/lib/tempest/run_tests.sh -s"

--- a/manifests/profile/tempest.pp
+++ b/manifests/profile/tempest.pp
@@ -32,6 +32,6 @@ class openstack::profile::tempest {
     alt_username          => $alt_user,
     alt_password          => $users[$alt_user]['password'],
     alt_tenant_name       => $users[$alt_user]['tenant'],
-    #require              => Neutron_network[$public_network_name],
+    require               => Class['::neutron::keystone::auth'],
   }
 }


### PR DESCRIPTION
Updated Tempest scripts to run a basic set of smoke tests.
Added dependency on neutron auth to ensure that the neutron
provider is initialized after neutron.conf is written
