### PR TITLE
Updated Glance to put glance-api.conf on controller

### DIFF
--- a/manifests/common/glance.pp
+++ b/manifests/common/glance.pp
@@ -1,0 +1,20 @@
+# Common class for Glance installation
+# Private, and should not be used on its own
+# The purpose is to have basic Glance auth configuration options
+# set so that services like Tempest can access credentials
+# on the controller
+class openstack::common::glance {
+  $is_storage = $::openstack::profile::base::is_storage
+
+  class { '::glance::api':
+    keystone_password => hiera('openstack::glance::password'),
+    auth_host         => hiera('openstack::controller::address::management'),
+    keystone_tenant   => 'services',
+    keystone_user     => 'glance',
+    sql_connection    => $::openstack::resources::connectors::glance,
+    registry_host     => hiera('openstack::storage::address::management'),
+    verbose           => hiera('openstack::verbose'),
+    debug             => hiera('openstack::debug'),
+    enabled           => $is_storage,
+  }
+}

--- a/manifests/profile/base.pp
+++ b/manifests/profile/base.pp
@@ -12,20 +12,19 @@ class openstack::profile::base {
   $management_network = hiera('openstack::network::management')
   $management_address = ip_for_network($management_network)
   $controller_management_address = hiera('openstack::controller::address::management')
+  $storage_management_address = hiera('openstack::storage::address::management')
 
   $management_matches = ($management_address == $controller_management_address)
+  $storage_management_matches = ($management_address == $storage_management_address)
 
   $api_network = hiera('openstack::network::api')
   $api_address = ip_for_network($api_network)
   $controller_api_address = hiera('openstack::controller::address::api')
+  $storage_api_address    = hiera('openstack::storage::address::api')
 
   $api_matches = ($api_address == $controller_api_address)
+  $storage_api_matches = ($api_address == $storage_api_address)
 
   $is_controller = ($management_matches and $api_matches)
-
-  if $is_controller {
-    notice("This node is a controller node. ${management_address} == ${controller_management_address} and ${api_address} == ${controller_api_address}")
-  } else {
-    notice("This node is not a controller node. ${management_address} != ${controller_management_address} or ${api_address} != ${controller_api_address}")
-  }
+  $is_storage    = ($storage_management_matches and $storage_api_matches)
 }

--- a/manifests/profile/glance/api.pp
+++ b/manifests/profile/glance/api.pp
@@ -32,16 +32,7 @@ class openstack::profile::glance::api {
   openstack::resources::firewall { 'Glance API': port      => '9292', }
   openstack::resources::firewall { 'Glance Registry': port => '9191', }
 
-  class { '::glance::api':
-    keystone_password => hiera('openstack::glance::password'),
-    auth_host         => hiera('openstack::controller::address::management'),
-    keystone_tenant   => 'services',
-    keystone_user     => 'glance',
-    sql_connection    => $::openstack::resources::connectors::glance,
-    registry_host     => hiera('openstack::storage::address::management'),
-    verbose           => hiera('openstack::verbose'),
-    debug             => hiera('openstack::debug'),
-  }
+  include ::openstack::common::glance
 
   class { '::glance::backend::file': }
 

--- a/manifests/profile/glance/auth.pp
+++ b/manifests/profile/glance/auth.pp
@@ -1,4 +1,5 @@
 # The profile to set up the endpoints, auth, and database for Glance
+# Because of the include, api must come before auth if colocated
 class openstack::profile::glance::auth {
   openstack::resources::controller { 'glance': }
   openstack::resources::database { 'glance': }
@@ -10,4 +11,6 @@ class openstack::profile::glance::auth {
     internal_address => hiera('openstack::storage::address::management'),
     region           => hiera('openstack::region'),
   }
+
+  include ::openstack::common::glance
 }

--- a/manifests/role/allinone.pp
+++ b/manifests/role/allinone.pp
@@ -7,7 +7,7 @@ class openstack::role::allinone inherits ::openstack::role {
   class { '::openstack::profile::keystone': } 
   class { '::openstack::profile::ceilometer::agent': }
   class { '::openstack::profile::ceilometer::api': }
-  class { '::openstack::profile::glance::api': }
+  class { '::openstack::profile::glance::api': } ->
   class { '::openstack::profile::glance::auth': }
   class { '::openstack::profile::cinder::volume': }
   class { '::openstack::profile::cinder::api': }

--- a/manifests/role/controller.pp
+++ b/manifests/role/controller.pp
@@ -14,5 +14,5 @@ class openstack::role::controller inherits ::openstack::role {
   class { '::openstack::profile::heat::api': } ->
   class { '::openstack::profile::horizon': }
   class { '::openstack::profile::auth_file': }
-  #class { '::openstack::profile::tempest': }
+  class { '::openstack::profile::tempest': }
 }


### PR DESCRIPTION
Tempest, when run from the controller, needs the *.conf
files to set up authentication tokens. Previously glance-api.conf
was not on the controller node, causing Tempest errors in relation
to working with images. This patch generalizes the Glance
in a manner similar to other services to create a glance-api.conf
file with auth tokens on the controller node.
