### PR TITLE
Updated Nova and Neutron settings for Icehouse

### DIFF
--- a/examples/allinone/Vagrantfile
+++ b/examples/allinone/Vagrantfile
@@ -39,6 +39,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     allinone.vm.provider "vmware_fusion" do |v|
         v.vmx["memsize"] =  "6144"
+        v.vmx["numvcpus"] = "4"
     end
   end
 

--- a/manifests/common/neutron.pp
+++ b/manifests/common/neutron.pp
@@ -41,6 +41,13 @@ class openstack::common::neutron {
     mysql_module        => '2.2',
   }
 
+  class { '::neutron::server::notifications':
+    nova_url            => "http://${controller_management_address}:8774/v2/",
+    nova_admin_auth_url => "http://${controller_management_address}:35357/v2.0/",
+    nova_admin_password => hiera('openstack::nova::password'),
+    nova_region_name    => hiera('openstack::region'),
+  }
+
   if $::osfamily == 'redhat' {
     package { 'iproute':
         ensure => latest,

--- a/manifests/common/nova.pp
+++ b/manifests/common/nova.pp
@@ -63,5 +63,7 @@ class openstack::common::nova ($is_compute    = false) {
     neutron_region_name    => hiera('openstack::region'),
     neutron_admin_auth_url => "http://${controller_management_address}:35357/v2.0",
     neutron_url            => "http://${controller_management_address}:9696",
+    vif_plugging_is_fatal  => false,
+    vif_plugging_timeout   => '0',
   }
 }

--- a/manifests/profile/nova/api.pp
+++ b/manifests/profile/nova/api.pp
@@ -6,6 +6,7 @@ class openstack::profile::nova::api {
   openstack::resources::firewall { 'Nova Metadata': port => '8775', }
   openstack::resources::firewall { 'Nova EC2': port => '8773', }
   openstack::resources::firewall { 'Nova S3': port => '3333', }
+  openstack::resources::firewall { 'Nova novnc': port => '6080', }
 
   class { '::nova::keystone::auth':
     password         => hiera('openstack::nova::password'),


### PR DESCRIPTION
Nova and Neutron now have stronger communication. This change
adds configuration to allow notifications between the two.
Nova will also ignore spurious Neutron failures when setting
up the virtual networking [1]. Firewall for vpn was not allowing
connections. Port was openend to allow console access.

[1] http://openstack.redhat.com/Workarounds#nova:_instances_started_in_error_state
