### PR TITLE
Updates to support OpenStack Icehouse.

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -64,7 +64,7 @@ mod "mysql",
 
 mod "stdlib",
   :git => "git://github.com/puppetlabs/puppetlabs-stdlib",
-  :ref => "4.x"
+  :ref => "3.2.x"
 
 mod "rsync",
   :git => "git://github.com/puppetlabs/puppetlabs-rsync",

--- a/examples/allinone/00_download_modules.sh
+++ b/examples/allinone/00_download_modules.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Set up the modules. This needs to be done before the boxes
+# are booted because VMWare and Vagrant are super buggy in
+# syncing files
+
+r10k -v info puppetfile install
+python ../../tools/review_checkout.py -u hogepodge -c 91128 | sh

--- a/examples/allinone/10_setup_master.sh
+++ b/examples/allinone/10_setup_master.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # Set up the Puppet Master
 
-r10k -v info puppetfile install
-
 vagrant ssh puppet -c "sudo service iptables stop; \
 sudo rpm -i http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm; \
 sudo yum install -y puppet-server; \

--- a/examples/allinone/firstrun.sh
+++ b/examples/allinone/firstrun.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+./00_download_modules.sh
 ./05_up.sh
 ./10_setup_master.sh
 ./11_setup_openstack.sh

--- a/examples/allinone/python27.sh
+++ b/examples/allinone/python27.sh
@@ -1,0 +1,23 @@
+yum -y groupinstall "Development tools"
+yum -y install zlib-devel bzip2-devel openssl-devel ncurses-devel sqlite-devel readline-devel tk-devel gdbm-devel db4-devel libpcap-devel xz-devel wget
+
+wget http://python.org/ftp/python/2.7.6/Python-2.7.6.tar.xz
+tar xf Python-2.7.6.tar.xz
+cd Python-2.7.6
+
+./configure --prefix=/usr/local --enable-unicode=ucs4 --enable-shared LDFLAGS="-Wl,-rpath /usr/local/lib"
+make && make altinstall
+
+cd ..
+wget https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py
+
+/usr/local/bin/python2.7 ez_setup.py
+/usr/local/bin/easy_install-2.7 pip
+
+/usr/local/bin/pip2.7 install virtualenv
+
+cd /var/lib/tempest
+rm -rf .venv
+/usr/local/bin/virtualenv .venv
+source .venv/bin/activate
+python tools/install_venv.py

--- a/manifests/common/neutron.pp
+++ b/manifests/common/neutron.pp
@@ -21,7 +21,9 @@ class openstack::common::neutron {
     debug                 => hiera('openstack::debug'),
     verbose               => hiera('openstack::verbose'),
     service_plugins       => ['neutron.services.loadbalancer.plugin.LoadBalancerPlugin',
-                              'neutron.services.vpn.plugin.VPNDriverPlugin'],
+                              'neutron.services.vpn.plugin.VPNDriverPlugin',
+                              'neutron.services.firewall.fwaas_plugin.FirewallPlugin',
+                              'neutron.services.metering.metering_plugin.MeteringPlugin'],
   }
 
   class { '::neutron::keystone::auth':

--- a/manifests/profile/neutron/router.pp
+++ b/manifests/profile/neutron/router.pp
@@ -44,6 +44,14 @@ class openstack::profile::neutron::router {
     enabled => true,
   }
 
+  class { '::neutron::agents::metering':
+    enabled => true,
+  }
+
+  class { '::neutron::services::fwaas':
+    enabled => true,
+  }
+
   # Temporarily fix a bug on RHEL packaging
   if $::osfamily == 'RedHat' {
     file { '/usr/lib/python2.6/site-packages/neutronclient/client.py':

--- a/manifests/setup/sharednetwork.pp
+++ b/manifests/setup/sharednetwork.pp
@@ -52,15 +52,5 @@ class openstack::setup::sharednetwork {
     dns_nameservers  => [$dns],
   } 
 
-  neutron_subnet { '10.0.2.0/24':
-    cidr             => '10.0.2.0/24',
-    ip_version       => '4',
-    enable_dhcp      => true,
-    network_name     => 'private',
-    tenant_name      => 'test',
-    dns_nameservers  => [$dns],
-  }
-
-  openstack::setup::router { "services:${private_network}": }
-  openstack::setup::router { 'test:10.0.2.0/24': }
+  openstack::setup::router { "test:${private_network}": }
 }


### PR DESCRIPTION
- Updated Puppetfile dependencies to support Icehouse on PE.
- Now pre-download modules to account for vagrant/fusion filesystem
  inconsistencies.
- Added a script to side-load python 27 for CentOS 6.5 systems to allow
  for Tempest testing.
- Added support for fwaas, lbaas, and metering.
- Updated shared networking and router config.
- Added interaction support for neutron/nova.
