### PR TITLE
Added Erlang dependency for updated RabbitMQ

### DIFF
--- a/manifests/profile/rabbitmq.pp
+++ b/manifests/profile/rabbitmq.pp
@@ -1,6 +1,13 @@
 # The profile to install rabbitmq and set the firewall
 class openstack::profile::rabbitmq {
   $management_address = hiera('openstack::controller::address::management')
+
+  package { 'erlang':
+    ensure  => installed,
+    before  => Package['rabbitmq-server'],
+    require => Yumrepo['erlang-solutions'],
+  }
+
   class { '::nova::rabbitmq':
     userid             => hiera('openstack::rabbitmq::user'),
     password           => hiera('openstack::rabbitmq::password'),

--- a/manifests/resources/repo.pp
+++ b/manifests/resources/repo.pp
@@ -9,6 +9,7 @@ class openstack::resources::repo(
     'icehouse', 'havana', 'grizzly': {
       if $::osfamily == 'RedHat' {
         class {'openstack::resources::repo::rdo': release => $release }
+        class {'openstack::resources::repo::erlang': }
       } elsif $::operatingsystem == 'Ubuntu' {
         class {'openstack::resources::repo::uca': release => $release }
       }

--- a/manifests/resources/repo/erlang.pp
+++ b/manifests/resources/repo/erlang.pp
@@ -1,0 +1,21 @@
+class openstack::resources::repo::erlang {
+  if $::osfamily == 'RedHat' {
+    case $::operatingsystem {
+      centos, redhat, scientific, slc: { $dist = 'centos' }
+      fedora: { $dist = 'fedora' }
+    }
+
+    $osver = regsubst($::operatingsystemrelease, '(\d+)\..*', '\1')
+
+    # http://packages.erlang-solutions.com/rpm/centos/6/x86_64/
+
+    yumrepo { 'erlang-solutions':
+      name     => 'erlang-solutions',
+      descr    => 'Erlang Solutions Repository',
+      baseurl  => "http://binaries.erlang-solutions.com/rpm/${dist}/${osver}/x86_64",
+      gpgcheck => 0,
+      gpgkey   => 'http://binaries.erlang-solutions.com/debian/erlang_solutions.asc',
+      enabled  => 1,
+    }
+  }
+}


### PR DESCRIPTION
The new puppetlabs-rabbitmq dependency requires a more
recent version of Erlang. Install the repo and package.
