### PR TITLE
Ubuntu 12.04 bug fixes

### DIFF
--- a/manifests/profile/mysql.pp
+++ b/manifests/profile/mysql.pp
@@ -14,6 +14,7 @@ class openstack::profile::mysql {
 
   class { '::mysql::server':
     root_password                => hiera('openstack::mysql::root_password'),
+    restart                      => true,
     override_options             => {
       'mysqld'                   => {
         'bind_address'           => hiera('openstack::controller::address::management'),

--- a/manifests/profile/rabbitmq.pp
+++ b/manifests/profile/rabbitmq.pp
@@ -2,10 +2,12 @@
 class openstack::profile::rabbitmq {
   $management_address = hiera('openstack::controller::address::management')
 
-  package { 'erlang':
-    ensure  => installed,
-    before  => Package['rabbitmq-server'],
-    require => Yumrepo['erlang-solutions'],
+  if $::osfamily == 'RedHat' {
+    package { 'erlang':
+      ensure  => installed,
+      before  => Package['rabbitmq-server'],
+      require => Yumrepo['erlang-solutions'],
+    }
   }
 
   class { '::nova::rabbitmq':


### PR DESCRIPTION
The database needs to be restarted to attach to the correct bind
address. Erlang does not need to be installed explicitly on Ubuntu.
