### PR TITLE
added parameters for  'enable_tunneling', tunnel_types' and 'tenant_network_type'

### DIFF
--- a/manifests/common/ovs.pp
+++ b/manifests/common/ovs.pp
@@ -1,15 +1,18 @@
 class openstack::common::ovs {
   $data_network = hiera('openstack::network::data')
   $data_address = ip_for_network($data_network)
+  $enable_tunneling = hiera('openstack::neutron::tunneling', true)
+  $tunnel_types = hiera('openstack::neutron::tunnel_types', [])
+  $tenant_network_type = hiera('openstack::neutron::tenant_network_type', 'gre')
 
   class { '::neutron::agents::ovs':
-    enable_tunneling => 'True',
+    enable_tunneling => $enable_tunneling,
     local_ip         => $data_address,
     enabled          => true,
-    tunnel_types     => ['gre',],
+    tunnel_types     => $tunnel_types,
   }
 
   class  { '::neutron::plugins::ovs':
-    tenant_network_type => 'gre',
+    tenant_network_type => $tenant_network_type,
   }
 }


### PR DESCRIPTION
By default tunneling is used with gre as tunnel_type. This makes it parameterized, so it is possible to choose a 'vlan' network type and disable tunneling (also the default in the neutron class)
