### PR TITLE
Conflict between glance module and openstack module

### DIFF
--- a/manifests/profile/glance/api.pp
+++ b/manifests/profile/glance/api.pp
@@ -52,8 +52,4 @@ class openstack::profile::glance::api {
     rabbit_userid   => hiera('openstack::rabbitmq::user'),
     rabbit_host     => hiera('openstack::controller::address::management'),
   }
-
-  if $::osfamily == 'Debian' {
-    glance_api_config { 'DEFAULT/image_cache_dir': value => '/var/lib/glance/image-cache/'}
-  }
 }


### PR DESCRIPTION
I removed the call to `glance_api_config` for `image_cache_dir` for debian family

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: 
Duplicate declaration: Glance_api_config[DEFAULT/image_cache_dir] 
is already declared in file 
/etc/puppet/environments/puppetmaster/modules/glance/manifests/api.pp:271; 
cannot redeclare at    /etc/puppet/environments/puppetmaster/modules/openstack/manifests/profile/glance/api.pp:57
```

Would there be some reason to keep the `glance_api_config` call? 
