### PR TITLE
Replace openvswitch plugin with ML2 plugin

### DIFF
--- a/manifests/common/neutron.pp
+++ b/manifests/common/neutron.pp
@@ -14,13 +14,14 @@ class openstack::common::neutron {
 
   class { '::neutron':
     rabbit_host           => $controller_management_address,
-    core_plugin           => 'neutron.plugins.openvswitch.ovs_neutron_plugin.OVSNeutronPluginV2',
+    core_plugin           => 'neutron.plugins.ml2.plugin.Ml2Plugin',
     allow_overlapping_ips => true,
     rabbit_user           => hiera('openstack::rabbitmq::user'),
     rabbit_password       => hiera('openstack::rabbitmq::password'),
     debug                 => hiera('openstack::debug'),
     verbose               => hiera('openstack::verbose'),
-    service_plugins       => ['neutron.services.loadbalancer.plugin.LoadBalancerPlugin',
+    service_plugins       => ['neutron.services.l3_router.l3_router_plugin.L3RouterPlugin',
+                              'neutron.services.loadbalancer.plugin.LoadBalancerPlugin',
                               'neutron.services.vpn.plugin.VPNDriverPlugin',
                               'neutron.services.firewall.fwaas_plugin.FirewallPlugin',
                               'neutron.services.metering.metering_plugin.MeteringPlugin'],

--- a/manifests/common/ovs.pp
+++ b/manifests/common/ovs.pp
@@ -3,18 +3,22 @@ class openstack::common::ovs {
   $data_address = ip_for_network($data_network)
   $enable_tunneling = hiera('openstack::neutron::tunneling', true)
   $tunnel_types = hiera('openstack::neutron::tunnel_types', ['gre'])
-  $tenant_network_type = hiera('openstack::neutron::tenant_network_type', 'gre')
-  $network_vlan_ranges = hiera('openstack::neutron::network_vlan_ranges', 'physnet1:1000:2000')
+  $tenant_network_type = hiera('openstack::neutron::tenant_network_type', ['gre'])
+  $type_drivers = hiera('openstack::neutron::type_drivers', ['gre'])
+  $mechanism_drivers = hiera('openstack::neutron::mechanism_drivers', ['openvswitch'])
+  $tunnel_id_ranges = hiera('openstack::neutron::tunnel_id_ranges', ['1:1000'])
 
-  class { '::neutron::agents::ovs':
+  class { '::neutron::agents::ml2::ovs':
     enable_tunneling => $enable_tunneling,
     local_ip         => $data_address,
     enabled          => true,
     tunnel_types     => $tunnel_types,
   }
 
-  class  { '::neutron::plugins::ovs':
-    tenant_network_type => $tenant_network_type,
-    network_vlan_ranges => $network_vlan_ranges
+  class  { '::neutron::plugins::ml2':
+    type_drivers      => $type_drivers,
+    tenant_network_types => $tenant_network_type,
+    mechanism_drivers => $mechanism_drivers,
+    tunnel_id_ranges  => $tunnel_id_ranges
   }
 }


### PR DESCRIPTION
Openvswitch monolithic plugin is going to be deprecated. From my POV it make sense to start using ML2 plugin instead.
