### PR TITLE
Don't install Ubuntu Cloud Archive PPA on 14.04

### DIFF
--- a/manifests/resources/repo/uca.pp
+++ b/manifests/resources/repo/uca.pp
@@ -4,7 +4,7 @@ class openstack::resources::repo::uca(
   $repo    = 'updates'
 ) {
   if ($::operatingsystem == 'Ubuntu' and
-      $::lsbdistdescription =~ /^.*LTS.*$/) {
+      $::lsbdistdescription =~ /^.*12\.04.*LTS.*$/) {
     include apt::update
 
     apt::source { 'ubuntu-cloud-archive':


### PR DESCRIPTION
Icehouse is in the default Ubuntu package repositories. No need
to install the Ubuntu Cloud Archive if you are installing on 14.04
