### PR TITLE
Fix typo in variable name

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,7 +24,7 @@ class openstack::config (
   $keystone_admin_email = undef,
   $keystone_admin_password = undef,
   $keystone_tenants = undef,
-  $keysotne_users = undef,
+  $keystone_users = undef,
   $glance_password = undef,
   $cinder_password = undef,
   $cinder_volume_size = undef,


### PR DESCRIPTION
Bad variable name in version I submitted. 
