### PR TITLE
Use include-style declarations for common classes

### DIFF
--- a/manifests/profile/base.pp
+++ b/manifests/profile/base.pp
@@ -4,7 +4,7 @@ class openstack::profile::base {
   include ::openstack
 
   # everyone also needs to be on the same clock
-  class { '::ntp': }
+  include ::ntp
 
   # all nodes need the OpenStack repository
   class { '::openstack::resources::repo': }

--- a/manifests/profile/firewall/pre.pp
+++ b/manifests/profile/firewall/pre.pp
@@ -20,7 +20,7 @@ class openstack::profile::firewall::pre {
     }
   }
 
-  class { '::firewall': }
+  include ::firewall
 
   # Default firewall rules, based on the RHEL defaults
   firewall { '0001 - related established':


### PR DESCRIPTION
Classes that are used commonly outside this module should be included
where possible to avoid duplicate declaration errors.  Many sites
will have their own base profiles that already define ntp and
firewall rules.
