### PR TITLE
Fix package_ensure value for cinder::volume

### DIFF
--- a/manifests/profile/cinder/volume.pp
+++ b/manifests/profile/cinder/volume.pp
@@ -13,7 +13,7 @@ class openstack::profile::cinder::volume {
   } ->
 
   class { '::cinder::volume':
-    package_ensure => true,
+    package_ensure => present,
     enabled        => true,
   }
 


### PR DESCRIPTION
true is not a valid value for the package type's ensure parameter.
Swap it for the legal value present.

At some point this could become parameterized, but this patch will be
effective for now.

Fixes #67 
