### PR TITLE
Remove dependency on puppet-tempest

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -17,7 +17,6 @@ dependency 'puppetlabs/nova',        '>=4.0.0 <5.0.0'
 dependency 'puppetlabs/heat',        '>=4.0.0 <5.0.0'
 dependency 'puppetlabs/ceilometer',  '>=4.0.0 <5.0.0'
 dependency 'puppetlabs/horizon',     '>=4.0.0 <5.0.0'
-dependency 'puppetlabs/tempest',     '>=3.0.0 <5.0.0'
 
 # Other Dependencies
 dependency 'puppetlabs/ntp',         '>=3.0.0 <4.0.0'

--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ and maintainable OpenStack deployments.
 
 * High availability and SSL-enabled endpoints are not provided by this module.
 
-Addressing these limitations is planned for a forthcoming release of the puppetlabs-openstack module.
+* The puppet-tempest module will not be installed as a dependency if this module is installed via the puppet module tool. The reasoning for this is that the puppet-tempest module is currently broken for Puppet Enterprise >= 3.3, which will also break installation of this module. puppet-tempest is not scheduled for release anytime soon. Use r10k with the Puppetfile, download from the puppet-tempest source, or puppet module install stackforge/puppet-tempest (on FOSS puppet) before using the tempest role.
+
 
 ##License
 Puppet Labs OpenStack - A Puppet Module for a Multi-Node OpenStack Icehouse Installation.

--- a/manifests/role/allinone.pp
+++ b/manifests/role/allinone.pp
@@ -20,5 +20,4 @@ class openstack::role::allinone inherits ::openstack::role {
   class { '::openstack::profile::auth_file': }
   class { '::openstack::setup::sharednetwork': }
   class { '::openstack::setup::cirros': }
-  class { '::openstack::profile::tempest': }
 }


### PR DESCRIPTION
Puppet-tempest does not install correctly on Puppet Enterprise >=3.3
with the puppet module tool. This commit removes the dependency on
puppet-tempest from the Modulefile and removes the default inclusion of
tempest on the allinone node.

Users wishing to use tempest can still include the tempest role on
their node. The Puppetfile will continue to depend on puppet-tempest.
