### PR TITLE
Pin apache to 1.2.x in Puppetfile

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -56,7 +56,7 @@ mod "vswitch",
 
 mod "apache",
   :git => "git://github.com/puppetlabs/puppetlabs-apache",
-  :ref => "1.1.1"
+  :ref => "1.2.x"
 
 mod "epel",
   :git => "git://github.com/stahnma/puppet-module-epel",


### PR DESCRIPTION
A bugfix in puppetlabs-apache 1.2.0 broke functionality in
puppet-horizon. The change was fixed in puppet-horizon 5.0.0 but is not
compatible with older versions of the apache module. This patch upgrades
the apache module to at least 1.2.