### PR TITLE
Fix travisCI issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 ---
 language: ruby
-bundler_args: --without development
+bundler_args: --without system_tests
 script: "bundle exec rake validate && bundle exec rake lint"
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-env:
-  matrix:
-    - PUPPET_GEM_VERSION="~> 3.5.0"
-    - PUPPET_GEM_VERSION="~> 3.6.0"
-    - PUPPET_GEM_VERSION="~> 3.7.0"
+matrix:
+  fast_finish: true
+  include:
+  - rvm: 1.9.3
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.0"
 notifications:
   email: false


### PR DESCRIPTION
This commit removes Ruby 1.8.7 and Puppet 2.7 from the TravisCI
configs. Since this module was never released with any CI it is safe to
remove these.