### PR TITLE
Fix multinode deploy for ubuntu master

### DIFF
--- a/examples/multinode/10_setup_master.sh
+++ b/examples/multinode/10_setup_master.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Set up the Puppet Master
 
-vagrant ssh puppet -c "sudo service iptables stop; \
+vagrant ssh puppet -c "sudo apt-get update; \
 sudo apt-get install -y puppetmaster; \
 sudo rmdir /etc/puppet/modules || sudo unlink /etc/puppet/modules; \
 sudo ln -s /vagrant/modules /etc/puppet/modules; \


### PR DESCRIPTION
When using ubuntu as the puppet master we don't need to worry about
iptables, but we should update apt before doing anything else.