### PR TITLE
Give the multinode controller more memory

### DIFF
--- a/examples/multinode/Vagrantfile
+++ b/examples/multinode/Vagrantfile
@@ -41,7 +41,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     control.vm.synced_folder "../../", "/openstack"
 
     control.vm.provider "vmware_fusion" do |v|
-        v.vmx["memsize"] =  "1024"
+        v.vmx["memsize"] =  "2048"
         v.vmx["vhv.enable"] = "TRUE"
     end
   end


### PR DESCRIPTION
The controller will fall over if only allowed 1G of memory. This commit
allows it 2G.