### PR TITLE
Rewrite the rabbitmq profile

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -103,7 +103,11 @@ mod "sysctl",
 
 mod "rabbitmq",
   :git => "git://github.com/puppetlabs/puppetlabs-rabbitmq",
-  :ref => "3.1.0"
+  :ref => "5.0.0"
+
+mod "staging",
+  :git => "git://github.com/nanliu/puppet-staging",
+  :ref => "1.x"
 
 mod "vcsrepo",
   :git => "git://github.com/puppetlabs/puppetlabs-vcsrepo",

--- a/examples/allinone/Vagrantfile
+++ b/examples/allinone/Vagrantfile
@@ -36,6 +36,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     allinone.vm.hostname = "allinone"
 
+    allinone.vm.provision "puppet" do |puppet|
+      puppet.manifests_path = "provision_manifests"
+      puppet.manifest_file = "base.pp"
+    end
+
     allinone.vm.synced_folder "../../", "/openstack"
 
     allinone.vm.provider "vmware_fusion" do |v|

--- a/examples/allinone/provision_manifests/base.pp
+++ b/examples/allinone/provision_manifests/base.pp
@@ -1,0 +1,20 @@
+# Point the node's hostname to 127.0.0.1
+#
+# The vagrant hostmanager points the node's hostname to its public IP in
+# /etc/hosts. This causes problems for the rabbitmq processes running
+# on localhost that use a number of different ports and use the host's
+# name to communicate with the cluster.
+#
+# Ideally we would configure the firewall to open the rabbitmq ports
+# and allow access to the rabbitmq nodes, but we can't restrict the
+# clustered node ports with early version of the rabbitmq module and
+# therefore we can't open those ports. Instead we just ensure that
+# requests on localhost use the localhost network. We will replace
+# this with firewall rules in the rabbitmq profile when all the
+# stackforge modules have upgraded to puppetlabs-rabbitmq >=5.x
+#
+host { 'localhost':
+  ensure => present,
+  name   => $::hostname,
+  ip     => '127.0.0.1',
+}

--- a/examples/multinode/Vagrantfile
+++ b/examples/multinode/Vagrantfile
@@ -38,6 +38,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     control.vm.hostname = "control"
 
+    control.vm.provision "puppet" do |puppet|
+      puppet.manifests_path = "provision_manifests"
+      puppet.manifest_file = "base.pp"
+    end
+
     control.vm.synced_folder "../../", "/openstack"
 
     control.vm.provider "vmware_fusion" do |v|

--- a/examples/multinode/provision_manifests/base.pp
+++ b/examples/multinode/provision_manifests/base.pp
@@ -1,0 +1,20 @@
+# Point the node's hostname to 127.0.0.1
+#
+# The vagrant hostmanager points the node's hostname to its public IP in
+# /etc/hosts. This causes problems for the rabbitmq processes running
+# on localhost that use a number of different ports and use the host's
+# name to communicate with the cluster.
+#
+# Ideally we would configure the firewall to open the rabbitmq ports
+# and allow access to the rabbitmq nodes, but we can't restrict the
+# clustered node ports with early version of the rabbitmq module and
+# therefore we can't open those ports. Instead we just ensure that
+# requests on localhost use the localhost network. We will replace
+# this with firewall rules in the rabbitmq profile when all the
+# stackforge modules have upgraded to puppetlabs-rabbitmq >=5.x
+#
+host { 'localhost':
+  ensure => present,
+  name   => $::hostname,
+  ip     => '127.0.0.1',
+}

--- a/examples/swift/Vagrantfile
+++ b/examples/swift/Vagrantfile
@@ -35,6 +35,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     control.vm.hostname = "control"
 
+    control.vm.provision "puppet" do |puppet|
+      puppet.manifests_path = "provision_manifests"
+      puppet.manifest_file = "base.pp"
+    end
+
     control.vm.synced_folder "../../", "/openstack"
 
     control.vm.provider "vmware_fusion" do |v|

--- a/examples/swift/provision_manifests/base.pp
+++ b/examples/swift/provision_manifests/base.pp
@@ -1,0 +1,20 @@
+# Point the node's hostname to 127.0.0.1
+#
+# The vagrant hostmanager points the node's hostname to its public IP in
+# /etc/hosts. This causes problems for the rabbitmq processes running
+# on localhost that use a number of different ports and use the host's
+# name to communicate with the cluster.
+#
+# Ideally we would configure the firewall to open the rabbitmq ports
+# and allow access to the rabbitmq nodes, but we can't restrict the
+# clustered node ports with early version of the rabbitmq module and
+# therefore we can't open those ports. Instead we just ensure that
+# requests on localhost use the localhost network. We will replace
+# this with firewall rules in the rabbitmq profile when all the
+# stackforge modules have upgraded to puppetlabs-rabbitmq >=5.x
+#
+host { 'localhost':
+  ensure => present,
+  name   => $::hostname,
+  ip     => '127.0.0.1',
+}


### PR DESCRIPTION
nova::rabbitmq should be going away soon, so it is best to stop using
it. Moreover, the nova::rabbitmq class depends on an old version of the
rabbitmq module that contains what in some contexts is considered a
security vulnerability. While we can't change the rabbitmq version in
the metadata.json file because it will cause a conflict with the other
openstack modules, we can update our code and Puppetfile to use the
newer version and its new dependencies while maintaining compatibility
with the old version.

This commit also adds a host entry for localhost rabbitmq so that
rabbitmq can restart without being blocked by the firewall.