### PR TITLE
Fix ceilometer mongo user

### DIFF
--- a/manifests/profile/ceilometer/api.pp
+++ b/manifests/profile/ceilometer/api.pp
@@ -45,13 +45,19 @@ class openstack::profile::ceilometer::api {
     require => Class['mongodb::server'],
   }
 
-  mongodb_user { 'ceilometer':
-    ensure        => present,
-    password_hash => mongodb_password('ceilometer', 'password'),
-    database      => 'ceilometer',
-    roles         => ['readWrite', 'dbAdmin'],
-    tries         => 10,
-    require       => [Class['mongodb::server'], Class['mongodb::client']],
+  $mongo_username = $::openstack::config::ceilometer_mongo_username
+  $mongo_password = $::openstack::config::ceilometer_mongo_password
+
+  if $mongo_username and $mongo_password {
+    mongodb_user { $mongo_username:
+      ensure        => present,
+      password_hash => mongodb_password($mongo_username, $mongo_password),
+      database      => 'ceilometer',
+      roles         => ['readWrite', 'dbAdmin'],
+      tries         => 10,
+      require       => [Class['mongodb::server'], Class['mongodb::client']],
+      before        => Exec['ceilometer-dbsync'],
+    }
   }
 
   Class['::mongodb::server'] -> Class['::mongodb::client'] -> Exec['ceilometer-dbsync']


### PR DESCRIPTION
The new feature in #127 added support for services connecting as
different users, but did not change the ceilometer profile to set up
those users. This was a problem because services were unable to connect
as the users they were configured to use. This change adds that
support.