### PR TITLE
Allow user to config `glance_api_servers` via hiera

### DIFF
--- a/examples/allinone.yaml
+++ b/examples/allinone.yaml
@@ -36,6 +36,7 @@ openstack::mysql::cinder::pass: 'fuva-wax'
 
 openstack::mysql::glance::user: 'glance'
 openstack::mysql::glance::pass: 'fuva-wax'
+openstack::glance::api_servers: ['172.16.33.4:9292']
 
 openstack::mysql::nova::user: 'nova'
 openstack::mysql::nova::pass: 'fuva-wax'

--- a/examples/common.yaml
+++ b/examples/common.yaml
@@ -36,6 +36,7 @@ openstack::mysql::cinder::pass: 'fuva-wax'
 
 openstack::mysql::glance::user: 'glance'
 openstack::mysql::glance::pass: 'fuva-wax'
+openstack::glance::api_servers: ['172.16.33.5:9292']
 
 openstack::mysql::nova::user: 'nova'
 openstack::mysql::nova::pass: 'fuva-wax'

--- a/manifests/common/nova.pp
+++ b/manifests/common/nova.pp
@@ -14,7 +14,7 @@ class openstack::common::nova ($is_compute    = false) {
 
   class { '::nova':
     sql_connection     => $::openstack::resources::connectors::nova,
-    glance_api_servers => "http://${storage_management_address}:9292",
+    glance_api_servers => join($::openstack::config::glance_api_servers, ','),
     memcached_servers  => ["${controller_management_address}:11211"],
     rabbit_hosts       => $::openstack::config::rabbitmq_hosts,
     rabbit_userid      => $::openstack::config::rabbitmq_user,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,6 +39,7 @@ class openstack::config (
   $keystone_tenants = undef,
   $keystone_users = undef,
   $glance_password = undef,
+  $glance_api_servers = undef,
   $cinder_password = undef,
   $cinder_volume_size = undef,
   $swift_password = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -149,6 +149,10 @@
 # [*glance_password*]
 #   The password for the glance user in Keystone.
 #
+# [*glance_api_servers*]
+#   Array of api servers, with port setting
+#   Example configuration: ['172.16.33.4:9292'] 
+#
 # ==Cinder
 # [*cinder_password*]
 #   The password for the cinder user in Keystone.
@@ -323,6 +327,7 @@ class openstack (
   $keystone_tenants = undef,
   $keystone_users = undef,
   $glance_password = undef,
+  $glance_api_servers = undef,
   $cinder_password = undef,
   $cinder_volume_size = undef,
   $swift_password = undef,
@@ -403,6 +408,7 @@ class openstack (
       keystone_tenants              => hiera(openstack::keystone::tenants),
       keystone_users                => hiera(openstack::keystone::users),
       glance_password               => hiera(openstack::glance::password),
+      glance_api_servers            => hiera(openstack::glance::api_servers),
       cinder_password               => hiera(openstack::cinder::password),
       cinder_volume_size            => hiera(openstack::cinder::volume_size),
       swift_password                => hiera(openstack::swift::password),
@@ -483,6 +489,7 @@ class openstack (
       keystone_tenants              => $keystone_tenants,
       keystone_users                => $keystone_users,
       glance_password               => $glance_password,
+      glance_api_servers            => $glance_api_servers,
       cinder_password               => $cinder_password,
       cinder_volume_size            => $cinder_volume_size,
       swift_password                => $swift_password,


### PR DESCRIPTION
glance api servers ipaddr may not always equal to the storage management address,
it might be virtual ipaddr instead of the static one under a HA configured environment.