### PR TITLE
not to setup the package if it is not required

### DIFF
--- a/manifests/common/ceilometer.pp
+++ b/manifests/common/ceilometer.pp
@@ -24,10 +24,12 @@ class openstack::common::ceilometer {
     rabbit_password => $::openstack::config::rabbitmq_password,
   }
 
-  class { '::ceilometer::api':
-    enabled           => $is_controller,
-    keystone_host     => $controller_management_address,
-    keystone_password => $::openstack::config::ceilometer_password,
+  if $is_controller {
+    class { '::ceilometer::api':
+      enabled           => $is_controller,
+      keystone_host     => $controller_management_address,
+      keystone_password => $::openstack::config::ceilometer_password,
+    }
   }
 
   class { '::ceilometer::db':

--- a/manifests/common/glance.pp
+++ b/manifests/common/glance.pp
@@ -4,17 +4,19 @@
 # set so that services like Tempest can access credentials
 # on the controller
 class openstack::common::glance {
-  class { '::glance::api':
-    keystone_password   => $::openstack::config::glance_password,
-    auth_host           => $::openstack::config::controller_address_management,
-    keystone_tenant     => 'services',
-    keystone_user       => 'glance',
-    database_connection => $::openstack::resources::connectors::glance,
-    registry_host       => $::openstack::config::storage_address_management,
-    verbose             => $::openstack::config::verbose,
-    debug               => $::openstack::config::debug,
-    enabled             => $::openstack::profile::base::is_storage,
-    mysql_module        => '2.2',
-    os_region_name      => $::openstack::region,
+  if $::openstack::profile::base::is_storage {
+    class { '::glance::api':
+      keystone_password   => $::openstack::config::glance_password,
+      auth_host           => $::openstack::config::controller_address_management,
+      keystone_tenant     => 'services',
+      keystone_user       => 'glance',
+      database_connection => $::openstack::resources::connectors::glance,
+      registry_host       => $::openstack::config::storage_address_management,
+      verbose             => $::openstack::config::verbose,
+      debug               => $::openstack::config::debug,
+      enabled             => $::openstack::profile::base::is_storage,
+      mysql_module        => '2.2',
+      os_region_name      => $::openstack::region,
+    }
   }
 }

--- a/manifests/common/neutron.pp
+++ b/manifests/common/neutron.pp
@@ -34,16 +34,17 @@ class openstack::common::neutron {
     region           => $::openstack::config::region,
   }
 
-  if $is_controller {
-    class { '::neutron::server':
-      auth_host           => $::openstack::config::controller_address_management,
-      auth_password       => $::openstack::config::neutron_password,
-      database_connection => $::openstack::resources::connectors::neutron,
-      enabled             => $is_controller,
-      sync_db             => $is_controller,
-      mysql_module        => '2.2',
-    }
+  class { '::neutron::server':
+    auth_host           => $::openstack::config::controller_address_management,
+    auth_password       => $::openstack::config::neutron_password,
+    database_connection => $::openstack::resources::connectors::neutron,
+    package_ensure      => $is_controller,
+    enabled             => $is_controller,
+    sync_db             => $is_controller,
+    mysql_module        => '2.2',
+  }
 
+  if $is_controller {
     class { '::neutron::server::notifications':
       nova_url            => "http://${controller_management_address}:8774/v2/",
       nova_admin_auth_url => "http://${controller_management_address}:35357/v2.0/",

--- a/manifests/common/neutron.pp
+++ b/manifests/common/neutron.pp
@@ -4,6 +4,8 @@
 # Flags install individual services as needed
 # This follows the suggest deployment from the neutron Administrator Guide.
 class openstack::common::neutron {
+  $is_controller = $::openstack::profile::base::is_controller
+
   $controller_management_address = $::openstack::config::controller_address_management
 
   $data_network = $::openstack::config::network_data
@@ -32,20 +34,22 @@ class openstack::common::neutron {
     region           => $::openstack::config::region,
   }
 
-  class { '::neutron::server':
-    auth_host           => $::openstack::config::controller_address_management,
-    auth_password       => $::openstack::config::neutron_password,
-    database_connection => $::openstack::resources::connectors::neutron,
-    enabled             => $::openstack::profile::base::is_controller,
-    sync_db             => $::openstack::profile::base::is_controller,
-    mysql_module        => '2.2',
-  }
+  if $is_controller {
+    class { '::neutron::server':
+      auth_host           => $::openstack::config::controller_address_management,
+      auth_password       => $::openstack::config::neutron_password,
+      database_connection => $::openstack::resources::connectors::neutron,
+      enabled             => $is_controller,
+      sync_db             => $is_controller,
+      mysql_module        => '2.2',
+    }
 
-  class { '::neutron::server::notifications':
-    nova_url            => "http://${controller_management_address}:8774/v2/",
-    nova_admin_auth_url => "http://${controller_management_address}:35357/v2.0/",
-    nova_admin_password => $::openstack::config::nova_password,
-    nova_region_name    => $::openstack::config::region,
+    class { '::neutron::server::notifications':
+      nova_url            => "http://${controller_management_address}:8774/v2/",
+      nova_admin_auth_url => "http://${controller_management_address}:35357/v2.0/",
+      nova_admin_password => $::openstack::config::nova_password,
+      nova_region_name    => $::openstack::config::region,
+    }
   }
 
   if $::osfamily == 'redhat' {

--- a/manifests/common/nova.pp
+++ b/manifests/common/nova.pp
@@ -26,26 +26,28 @@ class openstack::common::nova ($is_compute    = false) {
 
   nova_config { 'DEFAULT/default_floating_pool': value => 'public' }
 
-  class { '::nova::api':
-    admin_password                       => $::openstack::config::nova_password,
-    auth_host                            => $controller_management_address,
-    enabled                              => $is_controller,
-    neutron_metadata_proxy_shared_secret => $::openstack::config::neutron_shared_secret,
-  }
+  if $is_controller {
+    class { '::nova::api':
+      admin_password                       => $::openstack::config::nova_password,
+      auth_host                            => $controller_management_address,
+      enabled                              => $is_controller,
+      neutron_metadata_proxy_shared_secret => $::openstack::config::neutron_shared_secret,
+    }
 
-  class { '::nova::vncproxy':
-    host    => $::openstack::config::controller_address_api,
-    enabled => $is_controller,
-  }
+    class { '::nova::vncproxy':
+      host    => $::openstack::config::controller_address_api,
+      enabled => $is_controller,
+    }
 
-  class { [
-    'nova::scheduler',
-    'nova::objectstore',
-    'nova::cert',
-    'nova::consoleauth',
-    'nova::conductor'
-  ]:
-    enabled => $is_controller,
+    class { [
+      'nova::scheduler',
+      'nova::objectstore',
+      'nova::cert',
+      'nova::consoleauth',
+      'nova::conductor'
+    ]:
+      enabled => $is_controller,
+    }
   }
 
   # TODO: it's important to set up the vnc properly


### PR DESCRIPTION
if their `enabled` option is controlled by `$is_controller` or `$is_storage`, maybe we can just not setup them.