### PR TITLE
Have the mongodb module manage the mongo repo

### DIFF
--- a/manifests/profile/mongodb.pp
+++ b/manifests/profile/mongodb.pp
@@ -11,6 +11,10 @@ class openstack::profile::mongodb {
     is ${explicit_address}. Please correct this difference.")
   }
 
+  class { '::mongodb::globals':
+    manage_package_repo => true,
+  }
+
   class { '::mongodb::server':
     bind_ip => ['127.0.0.1', $::openstack::config::controller_address_management],
   }


### PR DESCRIPTION
There was a bugfix in the 0.10.0 release of the mongodb module for
idempotency of the mongodb_user, but it only fixes the bug if using a
2.6 version of mongodb. This patch has the mongodb::globals class
manage the package repo so we can get a modern mongodb and take
advantage of the bugfix.