### PR TITLE
Fix lint errors and error catching

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 
-PuppetLint.configuration.fail_on_warnings
+PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('relative')
 PuppetLint.configuration.send("disable_80chars")
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')

--- a/manifests/profile/rabbitmq.pp
+++ b/manifests/profile/rabbitmq.pp
@@ -11,10 +11,10 @@ class openstack::profile::rabbitmq {
   }
 
   rabbitmq_user { $::openstack::config::rabbitmq_user:
-    admin     => true,
-    password  => $::openstack::config::rabbitmq_password,
-    provider  => 'rabbitmqctl',
-    require   => Class['::rabbitmq'],
+    admin    => true,
+    password => $::openstack::config::rabbitmq_password,
+    provider => 'rabbitmqctl',
+    require  => Class['::rabbitmq'],
   }
   rabbitmq_user_permissions { "${openstack::config::rabbitmq_user}@/":
     configure_permission => '.*',


### PR DESCRIPTION
fail_on_warnings must be explicitly set to true in order to fail on
lint warnings instead of just errors.