### PR TITLE
Fix 122

### DIFF
--- a/manifests/common/cinder.pp
+++ b/manifests/common/cinder.pp
@@ -2,13 +2,13 @@
 # Private, and should not be used on its own
 class openstack::common::cinder {
   class { '::cinder':
-    database_connection  => $::openstack::resources::connectors::cinder,
-    rabbit_host     => $::openstack::config::controller_address_management,
-    rabbit_userid   => $::openstack::config::rabbitmq_user,
-    rabbit_password => $::openstack::config::rabbitmq_password,
-    debug           => $::openstack::config::debug,
-    verbose         => $::openstack::config::verbose,
-    mysql_module    => '2.2',
+    database_connection => $::openstack::resources::connectors::cinder,
+    rabbit_host         => $::openstack::config::controller_address_management,
+    rabbit_userid       => $::openstack::config::rabbitmq_user,
+    rabbit_password     => $::openstack::config::rabbitmq_password,
+    debug               => $::openstack::config::debug,
+    verbose             => $::openstack::config::verbose,
+    mysql_module        => '2.2',
   }
 
   $storage_server = $::openstack::config::storage_address_api

--- a/manifests/common/cinder.pp
+++ b/manifests/common/cinder.pp
@@ -2,7 +2,7 @@
 # Private, and should not be used on its own
 class openstack::common::cinder {
   class { '::cinder':
-    sql_connection  => $::openstack::resources::connectors::cinder,
+    database_connection  => $::openstack::resources::connectors::cinder,
     rabbit_host     => $::openstack::config::controller_address_management,
     rabbit_userid   => $::openstack::config::rabbitmq_user,
     rabbit_password => $::openstack::config::rabbitmq_password,

--- a/manifests/common/glance.pp
+++ b/manifests/common/glance.pp
@@ -5,16 +5,16 @@
 # on the controller
 class openstack::common::glance {
   class { '::glance::api':
-    keystone_password      => $::openstack::config::glance_password,
-    auth_host              => $::openstack::config::controller_address_management,
-    keystone_tenant        => 'services',
-    keystone_user          => 'glance',
-    database_connection    => $::openstack::resources::connectors::glance,
-    registry_host          => $::openstack::config::storage_address_management,
-    verbose                => $::openstack::config::verbose,
-    debug                  => $::openstack::config::debug,
-    enabled                => $::openstack::profile::base::is_storage,
-    mysql_module           => '2.2',
-    os_region_name         => $::openstack::region,
+    keystone_password   => $::openstack::config::glance_password,
+    auth_host           => $::openstack::config::controller_address_management,
+    keystone_tenant     => 'services',
+    keystone_user       => 'glance',
+    database_connection => $::openstack::resources::connectors::glance,
+    registry_host       => $::openstack::config::storage_address_management,
+    verbose             => $::openstack::config::verbose,
+    debug               => $::openstack::config::debug,
+    enabled             => $::openstack::profile::base::is_storage,
+    mysql_module        => '2.2',
+    os_region_name      => $::openstack::region,
   }
 }

--- a/manifests/common/glance.pp
+++ b/manifests/common/glance.pp
@@ -5,16 +5,16 @@
 # on the controller
 class openstack::common::glance {
   class { '::glance::api':
-    keystone_password => $::openstack::config::glance_password,
-    auth_host         => $::openstack::config::controller_address_management,
-    keystone_tenant   => 'services',
-    keystone_user     => 'glance',
-    sql_connection    => $::openstack::resources::connectors::glance,
-    registry_host     => $::openstack::config::storage_address_management,
-    verbose           => $::openstack::config::verbose,
-    debug             => $::openstack::config::debug,
-    enabled           => $::openstack::profile::base::is_storage,
-    mysql_module      => '2.2',
-    os_region_name    => $::openstack::region,
+    keystone_password      => $::openstack::config::glance_password,
+    auth_host              => $::openstack::config::controller_address_management,
+    keystone_tenant        => 'services',
+    keystone_user          => 'glance',
+    database_connection    => $::openstack::resources::connectors::glance,
+    registry_host          => $::openstack::config::storage_address_management,
+    verbose                => $::openstack::config::verbose,
+    debug                  => $::openstack::config::debug,
+    enabled                => $::openstack::profile::base::is_storage,
+    mysql_module           => '2.2',
+    os_region_name         => $::openstack::region,
   }
 }

--- a/manifests/common/keystone.pp
+++ b/manifests/common/keystone.pp
@@ -6,13 +6,13 @@ class openstack::common::keystone {
   }
 
   class { '::keystone':
-    admin_token          => $::openstack::config::keystone_admin_token,
-    database_connection  => $::openstack::resources::connectors::keystone,
-    verbose              => $::openstack::config::verbose,
-    debug                => $::openstack::config::debug,
-    enabled              => $::openstack::profile::base::is_controller,
-    admin_bind_host      => $admin_bind_host,
-    mysql_module         => '2.2',
+    admin_token         => $::openstack::config::keystone_admin_token,
+    database_connection => $::openstack::resources::connectors::keystone,
+    verbose             => $::openstack::config::verbose,
+    debug               => $::openstack::config::debug,
+    enabled             => $::openstack::profile::base::is_controller,
+    admin_bind_host     => $admin_bind_host,
+    mysql_module        => '2.2',
   }
 
   class { '::keystone::roles::admin':

--- a/manifests/common/keystone.pp
+++ b/manifests/common/keystone.pp
@@ -6,13 +6,13 @@ class openstack::common::keystone {
   }
 
   class { '::keystone':
-    admin_token     => $::openstack::config::keystone_admin_token,
-    sql_connection  => $::openstack::resources::connectors::keystone,
-    verbose         => $::openstack::config::verbose,
-    debug           => $::openstack::config::debug,
-    enabled         => $::openstack::profile::base::is_controller,
-    admin_bind_host => $admin_bind_host,
-    mysql_module    => '2.2',
+    admin_token          => $::openstack::config::keystone_admin_token,
+    database_connection  => $::openstack::resources::connectors::keystone,
+    verbose              => $::openstack::config::verbose,
+    debug                => $::openstack::config::debug,
+    enabled              => $::openstack::profile::base::is_controller,
+    admin_bind_host      => $admin_bind_host,
+    mysql_module         => '2.2',
   }
 
   class { '::keystone::roles::admin':

--- a/manifests/common/nova.pp
+++ b/manifests/common/nova.pp
@@ -13,15 +13,15 @@ class openstack::common::nova ($is_compute    = false) {
   $controller_management_address = $::openstack::config::controller_address_management
 
   class { '::nova':
-    sql_connection     => $::openstack::resources::connectors::nova,
-    glance_api_servers => join($::openstack::config::glance_api_servers, ','),
-    memcached_servers  => ["${controller_management_address}:11211"],
-    rabbit_hosts       => $::openstack::config::rabbitmq_hosts,
-    rabbit_userid      => $::openstack::config::rabbitmq_user,
-    rabbit_password    => $::openstack::config::rabbitmq_password,
-    debug              => $::openstack::config::debug,
-    verbose            => $::openstack::config::verbose,
-    mysql_module       => '2.2',
+    database_connection      => $::openstack::resources::connectors::nova,
+    glance_api_servers       => join($::openstack::config::glance_api_servers, ','),
+    memcached_servers        => ["${controller_management_address}:11211"],
+    rabbit_hosts             => $::openstack::config::rabbitmq_hosts,
+    rabbit_userid            => $::openstack::config::rabbitmq_user,
+    rabbit_password          => $::openstack::config::rabbitmq_password,
+    debug                    => $::openstack::config::debug,
+    verbose                  => $::openstack::config::verbose,
+    mysql_module             => '2.2',
   }
 
   nova_config { 'DEFAULT/default_floating_pool': value => 'public' }

--- a/manifests/common/nova.pp
+++ b/manifests/common/nova.pp
@@ -13,15 +13,15 @@ class openstack::common::nova ($is_compute    = false) {
   $controller_management_address = $::openstack::config::controller_address_management
 
   class { '::nova':
-    database_connection      => $::openstack::resources::connectors::nova,
-    glance_api_servers       => join($::openstack::config::glance_api_servers, ','),
-    memcached_servers        => ["${controller_management_address}:11211"],
-    rabbit_hosts             => $::openstack::config::rabbitmq_hosts,
-    rabbit_userid            => $::openstack::config::rabbitmq_user,
-    rabbit_password          => $::openstack::config::rabbitmq_password,
-    debug                    => $::openstack::config::debug,
-    verbose                  => $::openstack::config::verbose,
-    mysql_module             => '2.2',
+    database_connection => $::openstack::resources::connectors::nova,
+    glance_api_servers  => join($::openstack::config::glance_api_servers, ','),
+    memcached_servers   => ["${controller_management_address}:11211"],
+    rabbit_hosts        => $::openstack::config::rabbitmq_hosts,
+    rabbit_userid       => $::openstack::config::rabbitmq_user,
+    rabbit_password     => $::openstack::config::rabbitmq_password,
+    debug               => $::openstack::config::debug,
+    verbose             => $::openstack::config::verbose,
+    mysql_module        => '2.2',
   }
 
   nova_config { 'DEFAULT/default_floating_pool': value => 'public' }

--- a/manifests/profile/glance/api.pp
+++ b/manifests/profile/glance/api.pp
@@ -37,14 +37,14 @@ class openstack::profile::glance::api {
   class { '::glance::backend::file': }
 
   class { '::glance::registry':
-    keystone_password => $::openstack::config::glance_password,
-    sql_connection    => $::openstack::resources::connectors::glance,
-    auth_host         => $::openstack::config::controller_address_management,
-    keystone_tenant   => 'services',
-    keystone_user     => 'glance',
-    verbose           => $::openstack::config::verbose,
-    debug             => $::openstack::config::debug,
-    mysql_module      => '2.2',
+    keystone_password      => $::openstack::config::glance_password,
+    database_connection    => $::openstack::resources::connectors::glance,
+    auth_host              => $::openstack::config::controller_address_management,
+    keystone_tenant        => 'services',
+    keystone_user          => 'glance',
+    verbose                => $::openstack::config::verbose,
+    debug                  => $::openstack::config::debug,
+    mysql_module           => '2.2',
   }
 
   class { '::glance::notify::rabbitmq':

--- a/manifests/profile/glance/api.pp
+++ b/manifests/profile/glance/api.pp
@@ -37,14 +37,14 @@ class openstack::profile::glance::api {
   class { '::glance::backend::file': }
 
   class { '::glance::registry':
-    keystone_password      => $::openstack::config::glance_password,
-    database_connection    => $::openstack::resources::connectors::glance,
-    auth_host              => $::openstack::config::controller_address_management,
-    keystone_tenant        => 'services',
-    keystone_user          => 'glance',
-    verbose                => $::openstack::config::verbose,
-    debug                  => $::openstack::config::debug,
-    mysql_module           => '2.2',
+    keystone_password   => $::openstack::config::glance_password,
+    database_connection => $::openstack::resources::connectors::glance,
+    auth_host           => $::openstack::config::controller_address_management,
+    keystone_tenant     => 'services',
+    keystone_user       => 'glance',
+    verbose             => $::openstack::config::verbose,
+    debug               => $::openstack::config::debug,
+    mysql_module        => '2.2',
   }
 
   class { '::glance::notify::rabbitmq':

--- a/manifests/profile/heat/api.pp
+++ b/manifests/profile/heat/api.pp
@@ -24,15 +24,15 @@ class openstack::profile::heat::api {
   }
 
   class { '::heat':
-    sql_connection    => $::openstack::resources::connectors::heat,
-    rabbit_host       => $::openstack::config::controller_address_management,
-    rabbit_userid     => $::openstack::config::rabbitmq_user,
-    rabbit_password   => $::openstack::config::rabbitmq_password,
-    debug             => $::openstack::config::debug,
-    verbose           => $::openstack::config::verbose,
-    keystone_host     => $::openstack::config::controller_address_management,
-    keystone_password => $::openstack::config::heat_password,
-    mysql_module      => '2.2',
+    database_connection => $::openstack::resources::connectors::heat,
+    rabbit_host         => $::openstack::config::controller_address_management,
+    rabbit_userid       => $::openstack::config::rabbitmq_user,
+    rabbit_password     => $::openstack::config::rabbitmq_password,
+    debug               => $::openstack::config::debug,
+    verbose             => $::openstack::config::verbose,
+    keystone_host       => $::openstack::config::controller_address_management,
+    keystone_password   => $::openstack::config::heat_password,
+    mysql_module        => '2.2',
   }
 
   class { '::heat::api':

--- a/manifests/profile/nova/compute.pp
+++ b/manifests/profile/nova/compute.pp
@@ -8,7 +8,7 @@ class openstack::profile::nova::compute {
   }
 
   class { '::nova::compute::libvirt':
-    libvirt_type     => $::openstack::config::nova_libvirt_type,
+    libvirt_virt_type     => $::openstack::config::nova_libvirt_type,
     vncserver_listen => $management_address,
   }
 

--- a/manifests/profile/nova/compute.pp
+++ b/manifests/profile/nova/compute.pp
@@ -8,8 +8,8 @@ class openstack::profile::nova::compute {
   }
 
   class { '::nova::compute::libvirt':
-    libvirt_virt_type     => $::openstack::config::nova_libvirt_type,
-    vncserver_listen => $management_address,
+    libvirt_virt_type => $::openstack::config::nova_libvirt_type,
+    vncserver_listen  => $management_address,
   }
 
   class { 'nova::migration::libvirt':


### PR DESCRIPTION
Rebases and fixes whitespace issues for #122. Since the upstream nova module unexpectedly removed functionality of the sql_connection parameter from the stable branch, we need to speed up and backport this update.