### PR TITLE
Remove heat_stack_owner from default admin roles

### DIFF
--- a/manifests/resources/user.pp
+++ b/manifests/resources/user.pp
@@ -16,7 +16,7 @@ define openstack::resources::user (
   if $admin == true {
     keystone_user_role { "${name}@${tenant}":
       ensure => present,
-      roles  => ['_member_', 'admin', 'heat_stack_owner'],
+      roles  => ['_member_', 'admin'],
     }
   } else {
     keystone_user_role { "${name}@${tenant}":


### PR DESCRIPTION
Defaulting to add admin users to the heat_stack_owner role causes
problems if heat is not included in the deployment. This should be
managed somewhere else.