### PR TITLE
Use ::horizon::allow_hosts and ::horizon::server_aliases instead of ::horizon::fqdn

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -70,6 +70,8 @@ class openstack::config (
   $heat_password = undef,
   $heat_encryption_key = undef,
   $horizon_secret_key = undef,
+  $horizon_allowed_hosts = undef,
+  $horizon_server_aliases = undef,
   $tempest_configure_images    = undef,
   $tempest_image_name          = undef,
   $tempest_image_name_alt      = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -239,6 +239,16 @@
 # [*horizon_secret_key*]
 #   The secret key for the Horizon service.
 #
+# [*allowed_hosts*]
+#   List of hosts which will be set as value of ALLOWED_HOSTS
+#   parameter in settings_local.py. This is used by Django for
+#   security reasons. Can be set to * in environments where security is
+#   deemed unimportant.
+#
+# [*server_aliases*]
+#   List of names which should be defined as ServerAlias directives
+#   in vhost.conf.
+#
 # == Log levels
 # [*verbose*]
 #   Boolean. Determines if verbose is enabled for all OpenStack services.
@@ -358,6 +368,8 @@ class openstack (
   $heat_password = undef,
   $heat_encryption_key = undef,
   $horizon_secret_key = undef,
+  $horizon_allowed_hosts = undef,
+  $horizon_server_aliases = undef,
   $tempest_configure_images    = undef,
   $tempest_image_name          = undef,
   $tempest_image_name_alt      = undef,
@@ -441,6 +453,8 @@ class openstack (
       heat_password                 => hiera(openstack::heat::password),
       heat_encryption_key           => hiera(openstack::heat::encryption_key),
       horizon_secret_key            => hiera(openstack::horizon::secret_key),
+      horizon_allowed_hosts         => hiera(openstack::horizon::allowed_hosts, []),
+      horizon_server_aliases        => hiera(openstack::horizon::server_aliases, []),
       verbose                       => hiera(openstack::verbose),
       debug                         => hiera(openstack::debug),
       tempest_configure_images      => hiera(openstack::tempest::configure_images),
@@ -524,6 +538,8 @@ class openstack (
       heat_password                 => $heat_password,
       heat_encryption_key           => $heat_encryption_key,
       horizon_secret_key            => $horizon_secret_key,
+      horizon_allowed_hosts         => [],
+      horizon_server_aliases        => [],
       verbose                       => $verbose,
       debug                         => $debug,
       tempest_configure_images      => $tempest_configure_images,

--- a/manifests/profile/horizon.pp
+++ b/manifests/profile/horizon.pp
@@ -1,7 +1,8 @@
 # Profile to install the horizon web service
 class openstack::profile::horizon {
   class { '::horizon':
-    fqdn            => [ '127.0.0.1', $::openstack::config::controller_address_api, $::fqdn ],
+    allowed_hosts   => concat([ '127.0.0.1', $::openstack::config::controller_address_api, $::fqdn ], $::openstack::config::horizon_allowed_hosts),
+    server_aliases  => concat([ '127.0.0.1', $::openstack::config::controller_address_api, $::fqdn ], $::openstack::config::horizon_server_aliases),
     secret_key      => $::openstack::config::horizon_secret_key,
     cache_server_ip => $::openstack::config::controller_address_management,
 


### PR DESCRIPTION
Using the `::horizon::fqdn` parameter causes the following warning:

```
 (Scope(Class[Horizon])) Parameter fqdn is deprecated. Please use parameter allowed_hosts for setting ALLOWED_HOSTS in settings_local.py and parameter server_aliases for setting ServerAlias directives in vhost.conf.
```

The hard-coded list of hosts also prevents the use of a service virtual host name (i.e. you have to connect to the dashboard using the hostname).

This PR replaces the use of `::horizon::fqdn` with `::horizon::allowed_hosts` and `::horizon::server_aliases` in `openstack::profile::horizon`.

It also introduces 2 new hiera parameters: `openstack::horizon::allowed_hosts` and `openstack::horizon::server_aliases`, which allowes the corresponding parameters to be extended (i.e. to allow the use of service names).