### PR TITLE
Don't require that OVS agent run on neutron server

### DIFF
--- a/manifests/common/ml2.pp
+++ b/manifests/common/ml2.pp
@@ -1,19 +1,9 @@
-class openstack::common::ovs {
-  $data_network        = $::openstack::config::network_data
-  $data_address        = ip_for_network($data_network)
-  $enable_tunneling    = $::openstack::config::neutron_tunneling # true
-  $tunnel_types        = $::openstack::config::neutron_tunnel_types #['gre']
+# Private class
+class openstack::common::ml2 {
   $tenant_network_type = $::openstack::config::neutron_tenant_network_type # ['gre']
   $type_drivers        = $::openstack::config::neutron_type_drivers # ['gre']
   $mechanism_drivers   = $::openstack::config::neutron_mechanism_drivers # ['openvswitch']
   $tunnel_id_ranges    = $::openstack::config::neutron_tunnel_id_ranges # ['1:1000']
-
-  class { '::neutron::agents::ml2::ovs':
-    enable_tunneling => $enable_tunneling,
-    local_ip         => $data_address,
-    enabled          => true,
-    tunnel_types     => $tunnel_types,
-  }
 
   class  { '::neutron::plugins::ml2':
     type_drivers         => $type_drivers,

--- a/manifests/common/ml2/ovs.pp
+++ b/manifests/common/ml2/ovs.pp
@@ -1,0 +1,15 @@
+# Private class
+# Set up the OVS agent
+class openstack::common::ml2::ovs {
+  $data_network        = $::openstack::config::network_data
+  $data_address        = ip_for_network($data_network)
+  $enable_tunneling    = $::openstack::config::neutron_tunneling # true
+  $tunnel_types        = $::openstack::config::neutron_tunnel_types #['gre']
+
+  class { '::neutron::agents::ml2::ovs':
+    enable_tunneling => $enable_tunneling,
+    local_ip         => $data_address,
+    enabled          => true,
+    tunnel_types     => $tunnel_types,
+  }
+}

--- a/manifests/profile/neutron/agent.pp
+++ b/manifests/profile/neutron/agent.pp
@@ -1,5 +1,6 @@
 # The profile to set up a neutron agent
 class openstack::profile::neutron::agent {
   include ::openstack::common::neutron
-  include ::openstack::common::ovs
+  include ::openstack::common::ml2::ovs
+  include ::openstack::common::ml2
 }

--- a/manifests/profile/neutron/router.pp
+++ b/manifests/profile/neutron/router.pp
@@ -5,8 +5,11 @@ class openstack::profile::neutron::router {
   }
 
   $controller_management_address = $::openstack::config::controller_address_management
+
   include ::openstack::common::neutron
-  include ::openstack::common::ovs
+  include ::openstack::common::ml2::ovs
+  include ::openstack::common::ml2
+
 
   ### Router service installation
   class { '::neutron::agents::l3':

--- a/manifests/profile/neutron/server.pp
+++ b/manifests/profile/neutron/server.pp
@@ -5,7 +5,7 @@ class openstack::profile::neutron::server {
   openstack::resources::firewall { 'Neutron API': port => '9696', }
 
   include ::openstack::common::neutron
-  include ::openstack::common::ovs
+  include ::openstack::common::ml2
 
   Class['::neutron::db::mysql'] -> Exec['neutron-db-sync']
 }


### PR DESCRIPTION
Without this patch, the neutron::agents::ml2::ovs class was bundled
into the openstack::common::ovs class, which was included in the
neutron server profile. Since the OVS agent is not required to run on
the neutron server, include it only where it's actually needed.

Closes #107