### PR TITLE
Fix fedora

### DIFF
--- a/manifests/profile/rabbitmq.pp
+++ b/manifests/profile/rabbitmq.pp
@@ -4,9 +4,12 @@ class openstack::profile::rabbitmq {
 
   if $::osfamily == 'RedHat' {
     package { 'erlang':
-      ensure  => installed,
-      before  => Package['rabbitmq-server'],
-      require => Yumrepo['erlang-solutions'],
+      ensure => installed,
+      before => Package['rabbitmq-server'],
+    }
+    # Erlang solutions doesn't have a yum repo for Fedora >= 17, but Fedora has an up-to-date erlang
+    if $::operatingsystem != 'Fedora' {
+      Yumrepo['erlang-solutions'] -> Package['erlang']
     }
   }
 

--- a/manifests/resources/repo.pp
+++ b/manifests/resources/repo.pp
@@ -10,6 +10,7 @@ class openstack::resources::repo(
       if $::osfamily == 'RedHat' {
         class {'openstack::resources::repo::rdo': release => $release }
         class {'openstack::resources::repo::erlang': }
+        class {'openstack::resources::repo::yum_refresh': }
       } elsif $::osfamily == 'Debian' {
         class {'openstack::resources::repo::uca': release => $release }
       }

--- a/manifests/resources/repo/epel.pp
+++ b/manifests/resources/repo/epel.pp
@@ -2,7 +2,6 @@ class openstack::resources::repo::epel {
   if ($::osfamily == 'RedHat' and
       $::operatingsystem != 'Fedora' and
       $::operatingsystemmajrelease >= 6) {
-    include openstack::resources::repo::yum_refresh
 
     include ::epel
   }

--- a/manifests/resources/repo/erlang.pp
+++ b/manifests/resources/repo/erlang.pp
@@ -1,9 +1,6 @@
 class openstack::resources::repo::erlang {
-  if $::osfamily == 'RedHat' {
-    case $::operatingsystem {
-      fedora: { $dist = 'fedora' }
-      default: { $dist = 'centos' }
-    }
+  if $::osfamily == 'RedHat' and $::operatingsystem != 'Fedora' {
+    $dist = 'centos' # There isn't a repo for fedora >= 17
 
     $osver = regsubst($::operatingsystemrelease, '(\d+)\..*', '\1')
 

--- a/manifests/resources/repo/rdo.pp
+++ b/manifests/resources/repo/rdo.pp
@@ -21,7 +21,6 @@ class openstack::resources::repo::rdo(
       gpgcheck => 1,
       gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-RDO-${release_cap}",
       priority => 98,
-      notify   => Exec['yum_refresh'],
     }
     file { "/etc/pki/rpm-gpg/RPM-GPG-KEY-RDO-${release_cap}":
       source => "puppet:///modules/openstack/RPM-GPG-KEY-RDO-${release_cap}",

--- a/manifests/resources/repo/yum_refresh.pp
+++ b/manifests/resources/repo/yum_refresh.pp
@@ -4,5 +4,5 @@ class openstack::resources::repo::yum_refresh {
     command     => '/usr/bin/yum clean all',
     refreshonly => true,
   }
-  Exec['yum_refresh'] -> Package<||>
+  Yumrepo<||> ~> Exec['yum_refresh'] -> Package<||>
 }

--- a/metadata.json
+++ b/metadata.json
@@ -17,6 +17,10 @@
       "operatingsystemrelease": ["6", "7"]
     },
     {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": ["20", "21"]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": ["14.04"]
     }


### PR DESCRIPTION
Two commits here that fix deployments on Fedora 20 and 21:

1) Puppet was failing to add the erlang-solutions repo because Erlang doesn't provide a repo for newer versions of Fedora. Fixed by not requiring that repo on Fedora since the Fedora repos have new enough erlang.
2) A syntax issue was causing Puppet to fail trying to require the yum_refresh exec when that class wasn't included on Fedora. Fixed by reorganizing yum_refresh elements to make a little more sense.

Last commit formalizes support for Fedora in the metadata.