### PR TITLE
Use puppetdb in swift example

### DIFF
--- a/examples/swift/site.pp
+++ b/examples/swift/site.pp
@@ -1,5 +1,12 @@
 node 'puppet' {
   include ::ntp
+  class { '::puppetdb':
+    listen_address     => '0.0.0.0',
+    ssl_listen_address => '0.0.0.0'
+  }->
+  class { '::puppetdb::master::config':
+    puppetdb_server => 'puppet'
+  }
 }
 
 node 'control.localdomain' {


### PR DESCRIPTION
PuppetDB is required to run swift, so make sure it's installed in the
example.