### PR TITLE
Enable apache/wsgi setup for keystone API

### DIFF
--- a/manifests/common/keystone.pp
+++ b/manifests/common/keystone.pp
@@ -1,8 +1,14 @@
 class openstack::common::keystone {
   if $::openstack::profile::base::is_controller {
     $admin_bind_host = '0.0.0.0'
+    if $::openstack::config::keystone_use_httpd == true {
+      $service_name = 'httpd'
+    } else {
+      $service_name = undef
+    }
   } else {
     $admin_bind_host = $::openstack::config::controller_address_management
+    $service_name    = undef
   }
 
   class { '::keystone':
@@ -13,6 +19,7 @@ class openstack::common::keystone {
     enabled             => $::openstack::profile::base::is_controller,
     admin_bind_host     => $admin_bind_host,
     mysql_module        => '2.2',
+    service_name        => $service_name,
   }
 
   class { '::keystone::roles::admin':
@@ -20,4 +27,5 @@ class openstack::common::keystone {
     password     => $::openstack::config::keystone_admin_password,
     admin_tenant => 'admin',
   }
+
 }

--- a/manifests/common/neutron.pp
+++ b/manifests/common/neutron.pp
@@ -45,12 +45,14 @@ class openstack::common::neutron {
   }
 
   if $is_controller {
-    class { '::neutron::server::notifications':
-      nova_url            => "http://${controller_management_address}:8774/v2/",
-      nova_admin_auth_url => "http://${controller_management_address}:35357/v2.0/",
-      nova_admin_password => $::openstack::config::nova_password,
-      nova_region_name    => $::openstack::config::region,
-    }
+    anchor { 'neutron_common_first': } ->
+      class { '::neutron::server::notifications':
+        nova_url            => "http://${controller_management_address}:8774/v2/",
+        nova_admin_auth_url => "http://${controller_management_address}:35357/v2.0/",
+        nova_admin_password => $::openstack::config::nova_password,
+        nova_region_name    => $::openstack::config::region,
+      }
+    anchor { 'neutron_common_last': }
   }
 
   if $::osfamily == 'redhat' {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,6 +38,7 @@ class openstack::config (
   $keystone_admin_password = undef,
   $keystone_tenants = undef,
   $keystone_users = undef,
+  $keystone_use_httpd = undef,
   $glance_password = undef,
   $glance_api_servers = undef,
   $cinder_password = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,6 +145,14 @@
 #   'user2' => {'password' => 'somepass2', 'tenant' => 'some_preexisting_tenant',
 #                'email' => 'foo2@example.com', 'admin'  =>  'false'}} 
 #
+# [*keystone_use_httpd*]
+#   Whether to set up an Apache web service with mod_wsgi or to use the default
+#   Eventlet service. If false, the default from $keystone::params::service_name
+#   will be used, which will be the default Eventlet service. Set to true to
+#   configure an Apache web service using mod_wsgi, which is currently the only
+#   web service configuration available through the keystone module.
+#   Defaults to false.
+#
 # == Glance
 # [*glance_password*]
 #   The password for the glance user in Keystone.
@@ -332,6 +340,7 @@ class openstack (
   $keystone_admin_password = undef,
   $keystone_tenants = undef,
   $keystone_users = undef,
+  $keystone_use_httpd = false,
   $glance_password = undef,
   $glance_api_servers = undef,
   $cinder_password = undef,
@@ -415,6 +424,7 @@ class openstack (
       keystone_admin_password       => hiera(openstack::keystone::admin_password),
       keystone_tenants              => hiera(openstack::keystone::tenants),
       keystone_users                => hiera(openstack::keystone::users),
+      keystone_use_httpd            => hiera(openstack::keystone::use_httpd, false),
       glance_password               => hiera(openstack::glance::password),
       glance_api_servers            => hiera(openstack::glance::api_servers),
       cinder_password               => hiera(openstack::cinder::password),
@@ -498,6 +508,7 @@ class openstack (
       keystone_admin_password       => $keystone_admin_password,
       keystone_tenants              => $keystone_tenants,
       keystone_users                => $keystone_users,
+      keystone_use_httpd            => $keystone_use_httpd,
       glance_password               => $glance_password,
       glance_api_servers            => $glance_api_servers,
       cinder_password               => $cinder_password,

--- a/manifests/profile/keystone.pp
+++ b/manifests/profile/keystone.pp
@@ -14,6 +14,12 @@ class openstack::profile::keystone {
     region       => $::openstack::config::region,
   }
 
+  if $::openstack::config::keystone_use_httpd == true {
+    class { '::keystone::wsgi::apache':
+      ssl => false,
+    }
+  }
+
   $tenants = $::openstack::config::keystone_tenants
   $users   = $::openstack::config::keystone_users
   create_resources('openstack::resources::tenant', $tenants)

--- a/manifests/role/allinone.pp
+++ b/manifests/role/allinone.pp
@@ -22,4 +22,5 @@ class openstack::role::allinone inherits ::openstack::role {
   class { '::openstack::setup::cirros': }
 
   Class['::openstack::profile::ceilometer::api'] -> Class['::openstack::setup::cirros']
+  Class['::openstack::profile::keystone'] -> Class['::openstack::setup::cirros']
 }


### PR DESCRIPTION
Currently this module only supports using the default eventlet-based
web server for API services. This is only sustainable in a production
environment if using another web proxy in front of it, which is not
included in this module. This patch adds the ability to turn on the
keystone::wsgi::apache class and use the keystone API with Apache.

Other notes:
 - SSL is hard-coded to be turned off, since this module doesn't
   support SSL yet. We will fix this later.
 - Since the neutron::server::notifications class was not contained in
   the openstack::common::neutron class, the
   nova_admin_tenant_id_setter may try to authenticate against the
   keystone API before the HTTP service is turned on. We contain it
   within the openstack::common::neutron class with anchors so that the
   ordering of the profile classes is effective.
 - The keystone_use_httpd parameter was added to the openstack base
   class. It attempts a hiera lookup, but defaults to false, which
   signifies that it should not set up Apache.
 - The allinone role declares some setup classes in addition to
   profiles. The cirros setup involves making a keystone API call,
   which will fail if keystone isn't set up yet. We add a relationship
   between the keystone profile and the cirros setup following the
   example of the ceilometer API ordering.