### PR TITLE
Use Puppet Labs CentOS 7 vagrant box in examples

### DIFF
--- a/examples/allinone/30_deploy.sh
+++ b/examples/allinone/30_deploy.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Kick off the puppet runs, control is first for databases
-vagrant ssh allinone -c "sudo puppet agent -t"
+vagrant ssh allinone -c "sudo service firewalld stop; sudo puppet agent -t"

--- a/examples/allinone/Vagrantfile
+++ b/examples/allinone/Vagrantfile
@@ -28,7 +28,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "allinone" do |allinone|
-    allinone.vm.box = "jeffmccune/centos7"
+    allinone.vm.box = "puppetlabs/centos-7.0-64-puppet"
+    allinone.vm.box_version = "= 1.0.0"
     allinone.vm.network :private_network, ip: "192.168.11.4"
     allinone.vm.network :private_network, ip: "192.168.22.4"
     allinone.vm.network :private_network, ip: "172.16.33.4"

--- a/examples/multinode/30_deploy_control.sh
+++ b/examples/multinode/30_deploy_control.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Kick off the puppet runs, control is first for databases
-vagrant ssh control -c "sudo puppet agent -t"
+vagrant ssh control -c "sudo service firewalld stop; sudo puppet agent -t"

--- a/examples/multinode/40_deploy_nodes.sh
+++ b/examples/multinode/40_deploy_nodes.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Remainder of nodes follow
-vagrant ssh network -c "sudo puppet agent -t"
-vagrant ssh storage -c "sudo puppet agent -t"
-vagrant ssh compute -c "sudo puppet agent -t"
+vagrant ssh network -c "sudo service firewalld stop; sudo puppet agent -t"
+vagrant ssh storage -c "sudo service firewalld stop; sudo puppet agent -t"
+vagrant ssh compute -c "sudo service firewalld stop; sudo puppet agent -t"
 
 wait

--- a/examples/multinode/Vagrantfile
+++ b/examples/multinode/Vagrantfile
@@ -6,8 +6,6 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  config.vm.box = "jeffmccune/centos7"
-
   config.hostmanager.enabled = true
   config.hostmanager.manage_host = false
   config.hostmanager.ignore_private_ip = false
@@ -31,6 +29,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "control" do |control|
+    control.vm.box = "puppetlabs/centos-7.0-64-puppet"
+    control.vm.box_version = "= 1.0.0"
     control.vm.network :private_network, ip: "192.168.11.4"
     control.vm.network :private_network, ip: "192.168.22.4"
     control.vm.network :private_network, ip: "172.16.33.4"
@@ -52,6 +52,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "storage" do |storage|
+    storage.vm.box = "puppetlabs/centos-7.0-64-puppet"
+    storage.vm.box_version = "= 1.0.0"
     storage.vm.network :private_network, ip: "192.168.11.5"
     storage.vm.network :private_network, ip: "192.168.22.5"
     storage.vm.network :private_network, ip: "172.16.33.5"
@@ -68,6 +70,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "network" do |network|
+    network.vm.box = "puppetlabs/centos-7.0-64-puppet"
+    network.vm.box_version = "= 1.0.0"
     network.vm.network :private_network, ip: "192.168.11.6"
     network.vm.network :private_network, ip: "192.168.22.6"
     network.vm.network :private_network, ip: "172.16.33.6"
@@ -84,6 +88,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "compute" do |compute|
+    compute.vm.box = "puppetlabs/centos-7.0-64-puppet"
+    compute.vm.box_version = "= 1.0.0"
     compute.vm.network :private_network, ip: "192.168.11.7"
     compute.vm.network :private_network, ip: "192.168.22.7"
     compute.vm.network :private_network, ip: "172.16.33.7"
@@ -101,6 +107,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "swiftstore1" do |swiftstore1|
+    swiftstore1.vm.box = "puppetlabs/centos-7.0-64-puppet"
+    swiftstore1.vm.box_version = "= 1.0.0"
     swiftstore1.vm.network :private_network, ip: "192.168.11.8"
     swiftstore1.vm.network :private_network, ip: "192.168.22.8"
     swiftstore1.vm.network :private_network, ip: "172.16.33.8"
@@ -117,6 +125,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "swiftstore2" do |swiftstore2|
+    swiftstore2.vm.box = "puppetlabs/centos-7.0-64-puppet"
+    swiftstore2.vm.box_version = "= 1.0.0"
     swiftstore2.vm.network :private_network, ip: "192.168.11.9"
     swiftstore2.vm.network :private_network, ip: "192.168.22.9"
     swiftstore2.vm.network :private_network, ip: "172.16.33.9"
@@ -133,6 +143,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "swiftstore3" do |swiftstore3|
+    swiftstore3.vm.box = "puppetlabs/centos-7.0-64-puppet"
+    swiftstore3.vm.box_version = "= 1.0.0"
     swiftstore3.vm.network :private_network, ip: "192.168.11.10"
     swiftstore3.vm.network :private_network, ip: "192.168.22.10"
     swiftstore3.vm.network :private_network, ip: "172.16.33.10"
@@ -149,6 +161,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "tempest" do |tempest|
+    tempest.vm.box = "puppetlabs/centos-7.0-64-puppet"
+    tempest.vm.box_version = "= 1.0.0"
     tempest.vm.network :private_network, ip: "192.168.11.11"
     tempest.vm.network :private_network, ip: "192.168.22.11"
     tempest.vm.network :private_network, ip: "172.16.33.11"

--- a/examples/swift/25_deploy_swiftstore.sh
+++ b/examples/swift/25_deploy_swiftstore.sh
@@ -2,6 +2,6 @@
 #!/bin/bash
 
 # Kick off the puppet runs, control is first for databases
-vagrant ssh swiftstore1 -c "sudo puppet agent -t"
-vagrant ssh swiftstore2 -c "sudo puppet agent -t"
-vagrant ssh swiftstore3 -c "sudo puppet agent -t"
+vagrant ssh swiftstore1 -c "sudo service firewalld stop; sudo puppet agent -t"
+vagrant ssh swiftstore2 -c "sudo service firewalld stop; sudo puppet agent -t"
+vagrant ssh swiftstore3 -c "sudo service firewalld stop; sudo puppet agent -t"

--- a/examples/swift/30_deploy_control.sh
+++ b/examples/swift/30_deploy_control.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Kick off the puppet runs, control is first for databases
-vagrant ssh control -c "sudo puppet agent -t"
+vagrant ssh control -c "sudo service firewalld stop; sudo puppet agent -t"

--- a/examples/swift/Vagrantfile
+++ b/examples/swift/Vagrantfile
@@ -28,7 +28,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "control" do |control|
-    control.vm.box = "jeffmccune/centos7"
+    control.vm.box = "puppetlabs/centos-7.0-64-puppet"
+    control.vm.box_version = "= 1.0.0"
     control.vm.network :private_network, ip: "192.168.11.4"
     control.vm.network :private_network, ip: "192.168.22.4"
     control.vm.network :private_network, ip: "172.16.33.4"
@@ -49,7 +50,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "swiftstore1" do |swiftstore1|
-    swiftstore1.vm.box = "jeffmccune/centos7"
+    swiftstore1.vm.box = "puppetlabs/centos-7.0-64-puppet"
+    swiftstore1.vm.box_version = "= 1.0.0"
     swiftstore1.vm.network :private_network, ip: "192.168.11.8"
     swiftstore1.vm.network :private_network, ip: "192.168.22.8"
     swiftstore1.vm.network :private_network, ip: "172.16.33.8"
@@ -65,7 +67,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "swiftstore2" do |swiftstore2|
-    swiftstore2.vm.box = "jeffmccune/centos7"
+    swiftstore2.vm.box = "puppetlabs/centos-7.0-64-puppet"
+    swiftstore2.vm.box_version = "= 1.0.0"
     swiftstore2.vm.network :private_network, ip: "192.168.11.9"
     swiftstore2.vm.network :private_network, ip: "192.168.22.9"
     swiftstore2.vm.network :private_network, ip: "172.16.33.9"
@@ -81,7 +84,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.define "swiftstore3" do |swiftstore3|
-    swiftstore3.vm.box = "jeffmccune/centos7"
+    swiftstore3.vm.box = "puppetlabs/centos-7.0-64-puppet"
+    swiftstore3.vm.box_version = "= 1.0.0"
     swiftstore3.vm.network :private_network, ip: "192.168.11.10"
     swiftstore3.vm.network :private_network, ip: "192.168.22.10"
     swiftstore3.vm.network :private_network, ip: "172.16.33.10"


### PR DESCRIPTION
The Puppet Labs has multiple providers, so it is more accessible for
trying out the examples.

We're pinning the version to 1.0.0 because 1.0.1 seems to have issues
with its networking interfaces.

Additionally, this vagrant box comes with firewalld enabled and many
firewall rules. Firewalld responds to iptables-save which confuses the
firewall iptables provider and causes errors on the first round of
puppet runs, even if disabling firewalld is puppet's first change.
Because of this, we add a command to the deployment script to stop
firewalld before running puppet so that puppet succeeds on the first
run.