### PR TITLE
Remove class dependencies from firewall profile

### DIFF
--- a/manifests/profile/firewall/pre.pp
+++ b/manifests/profile/firewall/pre.pp
@@ -3,23 +3,10 @@
 class openstack::profile::firewall::pre {
 
   # Set up the initial firewall rules for all nodes
-  if $::osfamily == 'RedHat' {
-    firewallchain { 'INPUT:filter:IPv4':
-      purge   => true,
-      ignore  => ['neutron','virbr0'],
-      before  => Firewall['0001 - related established'],
-      require => [
-                  Class['::openstack::resources::repo::epel'],
-                  Class['::openstack::resources::repo::rdo'],
-      ],
-    }
-  } elsif $::osfamily == 'Debian' {
-    firewallchain { 'INPUT:filter:IPv4':
-      purge   => true,
-      ignore  => ['neutron','virbr0'],
-      before  => Firewall['0001 - related established'],
-      require => [ Class['::openstack::resources::repo::uca'] ],
-    }
+  firewallchain { 'INPUT:filter:IPv4':
+    purge  => true,
+    ignore => ['neutron','virbr0'],
+    before => Firewall['0001 - related established'],
   }
 
   include ::firewall


### PR DESCRIPTION
Profiles should be self-contained as much as possible. Removing the
dependency relationship between the firewallchain resources and the
repository classes causes no ill effects, plus it simplifies the code
because it is no longer conditional on osfamily.