### PR TITLE
Remove iptables-services package resource

### DIFF
--- a/manifests/profile/firewall.pp
+++ b/manifests/profile/firewall.pp
@@ -1,10 +1,4 @@
 class openstack::profile::firewall {
-  if $::osfamily == 'RedHat' and $::operatingsystemmajversion == 7 {
-    package { 'iptables-services':
-      ensure => present,
-    }
-    Package['iptables-services'] -> Firewall<||>
-  }
   class { '::openstack::profile::firewall::pre': }
   class { '::openstack::profile::firewall::puppet': }
   class { '::openstack::profile::firewall::post': }


### PR DESCRIPTION
The firewall module takes care of this for us. Moreover, the fact
is operatingsystemmajrelease, not operatingsystemmajversion, so this
was never being applied.