### PR TITLE
Ensure device mapper package is latest

### DIFF
--- a/manifests/profile/nova/compute.pp
+++ b/manifests/profile/nova/compute.pp
@@ -24,5 +24,11 @@ class openstack::profile::nova::compute {
     notify => Service['libvirt'],
   }
 
+  if $::osfamily == 'RedHat' {
+    package { 'device-mapper':
+      ensure => latest
+    }
+    Package['device-mapper'] ~> Service['libvirtd'] ~> Service['nova-compute']
+  }
   Package['libvirt'] -> File['/etc/libvirt/qemu.conf']
 }


### PR DESCRIPTION
Nova images won't boot with the version of device-mapper installed by
default on RedHat. We need to make sure we have the latest available
version, and it needs to refresh the libvirt and then the nova-compute
service after being updated.