### PR TITLE
Fix puppetlabs/mysql dependency

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -72,7 +72,7 @@ mod "inifile",
 
 mod "mysql",
   :git => "git://github.com/puppetlabs/puppetlabs-mysql",
-  :ref => "master"
+  :ref => "3.3.x"
 
 mod "stdlib",
   :git => "git://github.com/puppetlabs/puppetlabs-stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -41,7 +41,6 @@
     { "name": "puppetlabs/apache", "version_requirement": ">=1.2.0 <2.0.0" },
     { "name": "puppetlabs/firewall", "version_requirement": ">=1.0.0 <2.0.0" },
     { "name": "puppetlabs/mongodb", "version_requirement": ">=0.10.0 <0.11.0" },
-    { "name": "puppetlabs/mysql", "version_requirement": ">=2.2.0 <3.0.0" },
     { "name": "puppetlabs/ntp", "version_requirement": ">=3.0.0 <4.0.0" },
     { "name": "puppetlabs/rabbitmq", "version_requirement": ">=3.0.0 <4.0.0" },
     { "name": "stackforge/vswitch", "version_requirement": ">=1.0.0 <2.0.0" },


### PR DESCRIPTION
The stackforge/puppet-openstacklib module has updated its dependency on
puppetlabs-mysql to 3.x [1]. We do not need to have puppetlabs-mysql as
a dependency of this module as all the stackforge modules will pull
puppet-openstacklib in as a dependency, which pulls in
puppetlabs-mysql as a dependency.

This commit also pins puppetlabs-mysql to a stable 3.x branch in the
Puppetfile.

[1] https://review.openstack.org/#/c/149508/

Closes #187