### PR TITLE
Remove RedHat 6 from supported operating systems

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
-      "operatingsystemrelease": ["6", "7"]
+      "operatingsystemrelease": ["7"]
     },
     {
       "operatingsystem": "Fedora",


### PR DESCRIPTION
RDO only makes juno (and soon to be kilo) packages for RHEL 7, so
listing RedHat 6 as a supported operating system was a mistake.

Closes #189