### PR TITLE
Changed the cloud archive to the kilo release

### DIFF
--- a/manifests/resources/repo.pp
+++ b/manifests/resources/repo.pp
@@ -1,5 +1,5 @@
 class openstack::resources::repo(
-  $release = 'juno',
+  $release = 'kilo',
 ){
   if $::osfamily == 'Debian' {
     if $::operatingsystem == 'Ubuntu' {


### PR DESCRIPTION
As the kilo release is ready, we should change the cloud archive to install the OpenStack kilo packages.
