### PR TITLE
Fix for ip_for_network

### DIFF
--- a/lib/puppet/parser/functions/ip_for_network.rb
+++ b/lib/puppet/parser/functions/ip_for_network.rb
@@ -7,16 +7,21 @@ Returns an ip address for the given network in cidr notation
 
 ip_for_network("127.0.0.0/24") => 127.0.0.1
     EOS
-  ) do |args| 
-    addresses_in_range = [] 
+  ) do |args|
+    addresses_in_range = []
+    ip_addresses = []
+    interfaces = []
 
     range = IPAddr.new(args[0])
-    facts = compiler.node.facts.values
-    ip_addresses = facts.select { |key, value| key.match /^ipaddress/ }
+    interfaces = lookupvar('interfaces').split(",")
+    interfaces.each do |i|
+      ip = lookupvar("ipaddress_#{i}")
+      unless ip.nil?
+        ip_addresses.push(ip)
+      end
+    end
 
-    ip_addresses.each do |pair|
-      key = pair[0]
-      string_address = pair[1]
+    ip_addresses.each do |string_address|
       ip_address = IPAddr.new(string_address)
       if range.include?(ip_address)
         addresses_in_range.push(string_address)


### PR DESCRIPTION
I have a custom fact named "ipaddress_range" which was causing the ip_for_network function to bomb. This is a proposed fix which takes the list of interfaces and then looks up each IP address for the interfaces explicitly.