### PR TITLE
Topic rabbitmq newer version 

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -111,7 +111,7 @@ mod "sysctl",
 
 mod "rabbitmq",
   :git => "git://github.com/puppetlabs/puppetlabs-rabbitmq",
-  :ref => "5.0.0"
+  :ref => "5.2.0"
 
 mod "staging",
   :git => "git://github.com/nanliu/puppet-staging",

--- a/lib/puppet/parser/functions/ip_for_network.rb
+++ b/lib/puppet/parser/functions/ip_for_network.rb
@@ -7,16 +7,21 @@ Returns an ip address for the given network in cidr notation
 
 ip_for_network("127.0.0.0/24") => 127.0.0.1
     EOS
-  ) do |args| 
-    addresses_in_range = [] 
+  ) do |args|
+    addresses_in_range = []
+    ip_addresses = []
+    interfaces = []
 
     range = IPAddr.new(args[0])
-    facts = compiler.node.facts.values
-    ip_addresses = facts.select { |key, value| key.match /^ipaddress/ }
+    interfaces = lookupvar('interfaces').split(",")
+    interfaces.each do |i|
+      ip = lookupvar("ipaddress_#{i}")
+      unless ip.nil?
+        ip_addresses.push(ip)
+      end
+    end
 
-    ip_addresses.each do |pair|
-      key = pair[0]
-      string_address = pair[1]
+    ip_addresses.each do |string_address|
       ip_address = IPAddr.new(string_address)
       if range.include?(ip_address)
         addresses_in_range.push(string_address)

--- a/manifests/resources/repo.pp
+++ b/manifests/resources/repo.pp
@@ -1,5 +1,5 @@
 class openstack::resources::repo(
-  $release = 'juno',
+  $release = 'kilo',
 ){
   if $::osfamily == 'Debian' {
     if $::operatingsystem == 'Ubuntu' {


### PR DESCRIPTION
In rabbitmq 3.5.x the user/password check routine changed, therefore we need the newer version to guarantee idempotency
