### PR TITLE
we want to use vmware fusion and virtualbox as a vagrant provider

### DIFF
--- a/examples/allinone/05_up.sh
+++ b/examples/allinone/05_up.sh
@@ -1,4 +1,26 @@
 #!/bin/bash
 # This is the script for bringing up the standard openstack nodes without
 # Swift. This is probably the up script you want to run.
-vagrant up --provider vmware_fusion
+
+PROVIDER=${PROVIDER:-vmware_fusion}
+
+#---  FUNCTION  ----------------------------------------------------------------
+#          NAME:  provider
+#   DESCRIPTION:  checks for binary name in PATH
+#    PARAMETERS:  -
+#       RETURNS:  identifier for provider
+#-------------------------------------------------------------------------------
+provider ()
+{
+    if [[ -x `which vmware_fusion` ]]
+    then
+        echo "vmware_fusion"
+    elif [[ -x `which VirtualBox` ]]
+    then
+        echo "virtualbox"
+    else
+        exit 1
+    fi
+}   # ----------  end of function provider  ----------
+
+vagrant up --provider $(provider)

--- a/examples/allinone/Vagrantfile
+++ b/examples/allinone/Vagrantfile
@@ -25,6 +25,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     puppet.vm.provider "vmware_fusion" do |v|
         v.vmx["memsize"] =  "1024"
     end
+    puppet.vm.provider "virtualbox" do |vb|
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+      vb.memory   = 1024
+      vb.customize ["modifyvm", :id, "--natdnshostresolver1", "off"]
+    end
   end
 
   config.vm.define "allinone" do |allinone|
@@ -35,7 +40,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     allinone.vm.network :private_network, ip: "172.16.33.4"
     allinone.vm.network :private_network, ip: "172.16.44.4"
 
-    allinone.vm.hostname = "allinone"
+    allinone.vm.hostname = "allinone.localdomain"
 
     allinone.vm.provision "puppet" do |puppet|
       puppet.manifests_path = "provision_manifests"
@@ -48,6 +53,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         v.vmx["memsize"] =  "6144"
         v.vmx["numvcpus"] = "4"
         v.vmx["vhv.enable"] = "TRUE"
+    end
+    allinone.vm.provider "virtualbox" do |vb|
+        vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+        vb.customize ["modifyvm", :id, "--nicpromisc3", "allow-all"]
+        vb.cpus = 4
+        vb.memory = 6144
+		vb.customize ["modifyvm", :id, "--natdnspassdomain1", "off"]
     end
   end
 

--- a/examples/common.yaml
+++ b/examples/common.yaml
@@ -132,7 +132,7 @@ openstack::swift::hash_suffix: 'pop-bang'
 
 ######## Nova
 
-openstack::nova::libvirt_type: 'kvm'
+openstack::nova::libvirt_type: 'qemu'
 openstack::nova::password: 'quuk-paj'
 
 ######## Neutron

--- a/examples/multinode/05_up.sh
+++ b/examples/multinode/05_up.sh
@@ -1,4 +1,26 @@
 #!/bin/bash
 # This is the script for bringing up the standard openstack nodes without
 # Swift. This is probably the up script you want to run.
-vagrant up --provider vmware_fusion puppet control storage network compute
+
+PROVIDER=${PROVIDER:-vmware_fusion}
+
+#---  FUNCTION	----------------------------------------------------------------
+#		   NAME:  provider
+#	DESCRIPTION:  checks for binary name in PATH
+#	 PARAMETERS:  -
+#		RETURNS:  identifier for provider
+#-------------------------------------------------------------------------------
+provider ()
+{
+	if [[ -x `which vmware_fusion` ]]
+	then
+		echo "vmware_fusion"
+	elif [[ -x `which VirtualBox` ]]
+	then
+		echo "virtualbox"
+	else
+		exit 1
+	fi
+}	# ----------  end of function provider	----------
+
+vagrant up --provider $(provider) puppet control storage network compute

--- a/examples/multinode/Vagrantfile
+++ b/examples/multinode/Vagrantfile
@@ -26,6 +26,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         v.vmx["memsize"] =  "1024"
         v.vmx["vhv.enable"] = "TRUE"
     end
+    puppet.vm.provider "virtualbox" do |vb|
+      vb.memory = 1024
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+      vb.customize ["modifyvm", :id, "--natdnspassdomain1", "off"]
+    end
   end
 
   config.vm.define "control" do |control|
@@ -36,7 +41,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     control.vm.network :private_network, ip: "172.16.33.4"
     control.vm.network :private_network, ip: "172.16.44.4"
 
-    control.vm.hostname = "control"
+    control.vm.hostname = "control.localdomain"
 
     control.vm.provision "puppet" do |puppet|
       puppet.manifests_path = "provision_manifests"
@@ -49,6 +54,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         v.vmx["memsize"] =  "2048"
         v.vmx["vhv.enable"] = "TRUE"
     end
+    control.vm.provider "virtualbox" do |vb|
+      vb.memory = 2048
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+      vb.customize ["modifyvm", :id, "--natdnspassdomain1", "off"]
+    end
   end
 
   config.vm.define "storage" do |storage|
@@ -59,13 +69,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     storage.vm.network :private_network, ip: "172.16.33.5"
     storage.vm.network :private_network, ip: "172.16.44.5"
 
-    storage.vm.hostname = "storage"
+    storage.vm.hostname = "storage.localdomain"
 
     storage.vm.synced_folder "../../", "/openstack"
 
     storage.vm.provider "vmware_fusion" do |v|
         v.vmx["memsize"] =  "1024"
         v.vmx["vhv.enable"] = "TRUE"
+    end
+    storage.vm.provider "virtualbox" do |vb|
+      vb.memory   = 1024
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+      vb.customize ["modifyvm", :id, "--natdnspassdomain1", "off"]
     end
   end
 
@@ -77,13 +92,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     network.vm.network :private_network, ip: "172.16.33.6"
     network.vm.network :private_network, ip: "172.16.44.6"
 
-    network.vm.hostname = "network"
+    network.vm.hostname = "network.localdomain"
 
     network.vm.synced_folder "../../", "/openstack"
 
     network.vm.provider "vmware_fusion" do |v|
         v.vmx["memsize"] =  "1024"
         v.vmx["vhv.enable"] = "TRUE"
+    end
+    network.vm.provider "virtualbox" do |vb|
+      vb.memory = 1024
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+      vb.customize ["modifyvm", :id, "--nicpromisc3", "allow-all"]
+      vb.customize ["modifyvm", :id, "--natdnspassdomain1", "off"]
     end
   end
 
@@ -95,7 +116,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     compute.vm.network :private_network, ip: "172.16.33.7"
     compute.vm.network :private_network, ip: "172.16.44.7"
 
-    compute.vm.hostname = "compute"
+    compute.vm.hostname = "compute.localdomain"
 
     compute.vm.synced_folder "../../", "/openstack"
 
@@ -103,6 +124,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         v.vmx["numvcpus"] = "2"
         v.vmx["memsize"] =  "2048"
         v.vmx["vhv.enable"] = "TRUE"
+    end
+    compute.vm.provider "virtualbox" do |vb|
+      vb.cpus = 2
+      vb.memory = 2048
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+      vb.customize ["modifyvm", :id, "--nicpromisc3", "allow-all"]
+      vb.customize ["modifyvm", :id, "--natdnspassdomain1", "off"]
     end
   end
 
@@ -114,13 +142,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     swiftstore1.vm.network :private_network, ip: "172.16.33.8"
     swiftstore1.vm.network :private_network, ip: "172.16.44.8"
 
-    swiftstore1.vm.hostname = "swiftstore1"
+    swiftstore1.vm.hostname = "swiftstore1.localdomain"
 
     swiftstore1.vm.synced_folder "../../", "/openstack"
 
     swiftstore1.vm.provider "vmware_fusion" do |v|
         v.vmx["memsize"] =  "256"
         v.vmx["vhv.enable"] = "TRUE"
+    end
+    swiftstore1.vm.provider "virtualbox" do |vb|
+      vb.memory = 256
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+      vb.customize ["modifyvm", :id, "--natdnspassdomain1", "off"]
     end
   end
 
@@ -132,13 +165,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     swiftstore2.vm.network :private_network, ip: "172.16.33.9"
     swiftstore2.vm.network :private_network, ip: "172.16.44.9"
 
-    swiftstore2.vm.hostname = "swiftstore2"
+    swiftstore2.vm.hostname = "swiftstore2.localdomain"
 
     swiftstore2.vm.synced_folder "../../", "/openstack"
 
     swiftstore2.vm.provider "vmware_fusion" do |v|
         v.vmx["memsize"] =  "256"
         v.vmx["vhv.enable"] = "TRUE"
+    end
+    swiftstore2.vm.provider "virtualbox" do |vb|
+      vb.memory = 256
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+      vb.customize ["modifyvm", :id, "--natdnspassdomain1", "off"]
     end
   end
 
@@ -150,13 +188,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     swiftstore3.vm.network :private_network, ip: "172.16.33.10"
     swiftstore3.vm.network :private_network, ip: "172.16.44.10"
 
-    swiftstore3.vm.hostname = "swiftstore3"
+    swiftstore3.vm.hostname = "swiftstore3.localdomain"
 
     swiftstore3.vm.synced_folder "../../", "/openstack"
 
     swiftstore3.vm.provider "vmware_fusion" do |v|
         v.vmx["memsize"] =  "256"
         v.vmx["vhv.enable"] = "TRUE"
+    end
+    swiftstore3.vm.provider "virtualbox" do |vb|
+      vb.memory = 256
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+      vb.customize ["modifyvm", :id, "--natdnspassdomain1", "off"]
     end
   end
 
@@ -168,13 +211,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     tempest.vm.network :private_network, ip: "172.16.33.11"
     tempest.vm.network :private_network, ip: "172.16.44.11"
 
-    tempest.vm.hostname = "tempest"
+    tempest.vm.hostname = "tempest.localdomain"
 
     tempest.vm.synced_folder "../../", "/openstack"
 
     tempest.vm.provider "vmware_fusion" do |v|
       v.vmx["memsize"] = "512"
       v.vmx["vhv.enable"] = "TRUE"
+    end
+    tempest.vm.provider "virtualbox" do |vb|
+      vb.memory = 512
+      vb.customize ["modifyvm", :id, "--nictype1", "virtio"]
+      vb.customize ["modifyvm", :id, "--natdnspassdomain1", "off"]
     end
   end
 


### PR DESCRIPTION
```
add support for vagrant provider virtualbox

    * 05_up.sh detects installed provider and defaults vmware_fusion
    * Vagrantfile add nic, memory and vcpu customizations for virtualbox
    * examples/common.yaml change openstack:nova:libvirt_type to qemu
```
