### PR TITLE
In rabbitmq 3.5.x the user/password check routine changed, therefore …

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -111,7 +111,7 @@ mod "sysctl",
 
 mod "rabbitmq",
   :git => "git://github.com/puppetlabs/puppetlabs-rabbitmq",
-  :ref => "5.0.0"
+  :ref => "5.2.0"
 
 mod "staging",
   :git => "git://github.com/nanliu/puppet-staging",


### PR DESCRIPTION
…we need the newer version to guarantee idempotency
