### PR TITLE
Fix deprecate port parameter

### DIFF
--- a/manifests/profile/firewall/pre.pp
+++ b/manifests/profile/firewall/pre.pp
@@ -32,7 +32,7 @@ class openstack::profile::firewall::pre {
     proto  => 'tcp',
     state  => ['NEW', 'ESTABLISHED', 'RELATED'],
     action => 'accept',
-    port   => 22,
+    dport  => 22,
     before => [ Firewall['8999 - Accept all management network traffic'] ],
   }
 }

--- a/manifests/profile/swift/storage.pp
+++ b/manifests/profile/swift/storage.pp
@@ -9,21 +9,21 @@ class openstack::profile::swift::storage (
     proto  => 'tcp',
     state  => ['NEW'],
     action => 'accept',
-    port   => '6000',
+    dport  => '6000',
   }
 
   firewall { '6001 - Swift Container Store':
     proto  => 'tcp',
     state  => ['NEW'],
     action => 'accept',
-    port   => '6001',
+    dport  => '6001',
   }
 
   firewall { '6002 - Swift Account Store':
     proto  => 'tcp',
     state  => ['NEW'],
     action => 'accept',
-    port   => '6002',
+    dport  => '6002',
   }
 
   class { '::swift':

--- a/manifests/resources/firewall.pp
+++ b/manifests/resources/firewall.pp
@@ -5,7 +5,7 @@ define openstack::resources::firewall ( $port ) {
       proto  => 'tcp',
       state  => ['NEW'],
       action => 'accept',
-      port   => $port,
+      dport  => $port,
       before => Firewall['8999 - Accept all management network traffic'],
     }
   } else {
@@ -13,7 +13,7 @@ define openstack::resources::firewall ( $port ) {
       proto  => 'tcp',
       state  => ['NEW'],
       action => 'accept',
-      port   => $port,
+      dport  => $port,
       before => Firewall['8999 - Accept all management network traffic'],
     }
   }


### PR DESCRIPTION
follow the change of `puppetlabs-firewall (version 1.7.1)`,
all port-related firewall rules should define its sport/dport explicitly.

details:
- https://github.com/puppetlabs/puppetlabs-firewall/pull/569
- https://github.com/puppetlabs/puppetlabs-firewall/pull/570
