### PR TITLE
fix_CVE-2014-8160_gre-tunneling-issue

### DIFF
--- a/manifests/profile/firewall.pp
+++ b/manifests/profile/firewall.pp
@@ -2,4 +2,20 @@ class openstack::profile::firewall {
   class { '::openstack::profile::firewall::pre': }
   class { '::openstack::profile::firewall::puppet': }
   class { '::openstack::profile::firewall::post': }
+
+  # fix side effect of CVE-2014-8160 patch:
+  #   after applying a kernel upgrade, netfilter default behavior changed,
+  #   without this change, guest instacnes running on node with gre tunnel
+  #   may have no network access, we need to load an extra kernel module
+  #   `nf_conntrack_proto_gre` explicitly to resolve this issue.
+  #
+  # references:
+  #   http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=db29a9508a9246e77087c5531e45b2c88ec6988b
+  #   http://www.spinics.net/lists/netfilter-devel/msg33430.html
+  #   https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-8160
+
+  if (($::openstack::config::neutron_tunneling == true) and
+    (member($::openstack::config::neutron_tenant_network_type, ['gre']))) {
+    ::kmod::load { 'nf_conntrack_proto_gre': }
+  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -46,6 +46,8 @@
     { "name": "puppetlabs/rabbitmq", "version_requirement": ">=3.0.0 <4.0.0" },
     { "name": "stackforge/vswitch", "version_requirement": ">=1.0.0 <2.0.0" },
 
+    { "name": "camptocamp/kmod", "version_requirement": ">=2.1.0 <3.0.0" },
+
     { "name": "garethr/erlang", "version_requirement": "0.3.0" },
     { "name": "duritong/sysctl", "version_requirement": "0.0.1" }
   ]


### PR DESCRIPTION
fix side effect of CVE-2014-8160 patch:
  after applying a kernel upgrade, netfilter default behavior changed,
  without this change, guest instacnes running on node with gre tunnel
  may have no network access, we need to load an extra kernel module
  `nf_conntrack_proto_gre` explicitly to resolve this issue.

references:
  http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=db29a9508a9246e77087c5531e45b2c88ec6988b
  http://www.spinics.net/lists/netfilter-devel/msg33430.html
  https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-8160

step for reproduce:
1. setup a compute node without CVE-2014-8160 patch
   
    Ubuntu, for example,
   - Ubuntu Precise (kernel version < 3.13.0-46.75~precise1), for havana.
   - Ubuntu Trusty (kernel version < 3.16.0-31.41~14.04.1), for icehouse, juno, kilo, etc.
     
     reference:
   - http://people.canonical.com/~ubuntu-security/cve/2014/CVE-2014-8160.html
2. launch a guest instance
3. try to ping guest instance's gateway from inside guest instance
     ping test should passed
4. upgrade compute nodes' kernel
   
    Ubuntu, for example,
   - Ubuntu Precise (kernel version >= 3.13.0-46.75~precise1), for havana.
   - Ubuntu Trusty (kernel version >= 3.16.0-31.41~14.04.1), for icehouse, juno, kilo, etc.
     
     reference:
   - http://people.canonical.com/~ubuntu-security/cve/2014/CVE-2014-8160.html
5. repeat step 2 & 3 again
     ping test should failed, guest instance have no access to the networks
